### PR TITLE
[OCDM] Keep track of upgrade to SystemExt

### DIFF
--- a/Source/ocdm/open_cdm_ext.cpp
+++ b/Source/ocdm/open_cdm_ext.cpp
@@ -97,6 +97,7 @@ opencdm_create_system_ext(struct OpenCDMAccessor* system,
     ASSERT(system != nullptr);
 
     OpenCDMAccessor* accessor = system;
+    accessor->SetIsExtendedSystem(true);
     accessor->CreateSystemExt(keySystem);
     accessor->InitSystemExt(keySystem);
 
@@ -400,8 +401,7 @@ opencdm_construct_session(struct OpenCDMAccessor* system, const char keySystem[]
 
     TRACE_L1("Creating a Session for %s", keySystem);
 
-    // TODO: Since we are passing key system name anyway, not need for if here.
-    if (strcmp(keySystem, "com.netflix.playready") != 0) {
+    if (!system->IsExtendedSystem()) {
         if (system != nullptr) {
             *session = new ExtendedOpenCDMSession(
                 static_cast<OCDM::IAccessorOCDM*>(system), std::string(keySystem),

--- a/Source/ocdm/open_cdm_impl.h
+++ b/Source/ocdm/open_cdm_impl.h
@@ -151,6 +151,7 @@ private:
         , _interested(0)
         , _sessionKeys()
         , _sink(this)
+        , _extSystem(false)
     {
         printf("Trying to open an OCDM connection @ %s\n", domainName);
 
@@ -537,6 +538,16 @@ public:
             secureStoreHashLength);
     }
 
+    bool IsExtendedSystem() const
+    {
+        return _extSystem;
+    }
+
+    void SetIsExtendedSystem(bool isExtSystem)
+    {
+        _extSystem = isExtSystem;
+    }
+
 private:
     mutable uint32_t _refCount;
 	Core::ProxyType<RPC::InvokeServerType<4, 1> > _engine;
@@ -548,6 +559,7 @@ private:
     mutable volatile uint32_t _interested;
     std::map<string, std::list<KeyId>> _sessionKeys;
     WPEFramework::Core::Sink<Sink> _sink;
+    bool _extSystem; // whether it has been upgraded to extended system.
     static OpenCDMAccessor* _singleton;
 };
 


### PR DESCRIPTION
@pwielders : a simple way to keep track of whether a system got "upgraded" to systemext. As discussed we might improve this with real polymorphism, but maybe for now this is enough?