### PR TITLE
[Core] Unregistering the handler in IPC server.

### DIFF
--- a/Source/core/IPCChannel.h
+++ b/Source/core/IPCChannel.h
@@ -230,6 +230,7 @@ namespace Core {
             Close(infinite);
 
             if (_clients.size() > 0) {
+                InternalCleanup();
 
                 TRACE_L1("Closing clients that should have been closed before destruction [%d].", static_cast<uint32_t>(_clients.size()));
                 CloseClients();
@@ -307,13 +308,6 @@ namespace Core {
             std::map<uint32_t, ProxyType<IIPCServer>>::iterator index(_handlers.find(id));
 
             ASSERT(index != _handlers.end());
-
-            typename ClientMap::iterator cleaner(_clients.begin());
-            while (cleaner != _clients.end()) {
-                if (cleaner->second->IsClosed() == true)
-                    cleaner->second->Unregister(index->first);
-                cleaner++;
-            }
 
             if (index != _handlers.end()) {
                 _handlers.erase(index);

--- a/Source/core/IPCChannel.h
+++ b/Source/core/IPCChannel.h
@@ -308,6 +308,13 @@ namespace Core {
 
             ASSERT(index != _handlers.end());
 
+            typename ClientMap::iterator cleaner(_clients.begin());
+            while (cleaner != _clients.end()) {
+                if (cleaner->second->IsClosed() == true)
+                    cleaner->second->Unregister(index->first);
+                cleaner++;
+            }
+
             if (index != _handlers.end()) {
                 _handlers.erase(index);
             }


### PR DESCRIPTION
The handlers are registered after client connection. But not unregistered after connection closes or in destructor and its causing ASSERT on destruction.
https://github.com/WebPlatformForEmbedded/Thunder/blob/7214bcfcf984de5703f54ec9e129be1a65e16a8d/Source/core/IPCConnector.h#L742

I have put a fix for that.