### PR TITLE
[SerialPort] Fixed problem which caused crash on closing device file

### DIFF
--- a/Source/core/SerialPort.cpp
+++ b/Source/core/SerialPort.cpp
@@ -643,35 +643,27 @@ namespace Core {
         if (m_Descriptor != -1) {
             // Before we delete the descriptor, get ride of the Trigger
             // subscribtion.
+            Core::ResourceMonitor::Instance().Unregister(*this);
             m_State |= SerialPort::EXCEPTION;
             m_State &= ~SerialPort::OPEN;
             close(m_Descriptor);
             m_Descriptor = -1;
-            ResourceMonitor::Instance().Break();
-
-            m_syncAdmin.Unlock();
-
-            WaitForClosure(waitTime);
-        } else {
+            Closed();
+        }
 #endif
 
 #ifdef __WIN32__
             if (m_Descriptor != INVALID_HANDLE_VALUE) {
-
+                Core::ResourceMonitor::Instance().Unregister(*this);
                 m_State |= SerialPort::EXCEPTION;
                 m_State &= ~SerialPort::OPEN;
                 ::CloseHandle(m_Descriptor);
                 m_Descriptor = INVALID_HANDLE_VALUE;
-                g_SerialPortMonitor.Break();
-
-                m_syncAdmin.Unlock();
-
-                WaitForClosure(waitTime);
-            } else {
+                Closed();
+            } 
 #endif
 
                 m_syncAdmin.Unlock();
-            }
 
             return (Core::ERROR_NONE);
         }


### PR DESCRIPTION
The problem was that setting m_Descriptor = -1 right after closing file cased problems in ResourceMonitor, where  SerialPort::Descriptor() would return -1, while _descriptorArray had still old value. 

That casued assert
```
[ResourceMonitor.h:350] ASSERT(entry->Descriptor() == _descriptorArray[fd_index].fd);
```
to not hold true.
The solution is to unregister from ResourceMonitor as soon as serial device file is closed

