### PR TITLE
compositor/Client: Include <string> instead of string.h

### DIFF
--- a/Source/compositorclient/Client.h
+++ b/Source/compositorclient/Client.h
@@ -5,7 +5,7 @@
 #include <cstddef>
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
-#include <string.h>
+#include <string>
 
 #if __cplusplus <= 199711L
 #define nullptr NULL


### PR DESCRIPTION
its using std::string, therefore C++ header should be included, newer
compilers and C++ runtimes are less forgiving than g++/libstdc++ and
complain about std::string missing

Signed-off-by: Khem Raj <raj.khem@gmail.com>