### PR TITLE
[FileSystem] Fixed problems with parentheses in File::Create

### DIFF
--- a/Source/core/FileSystem.h
+++ b/Source/core/FileSystem.h
@@ -289,7 +289,7 @@ namespace Core {
 
         bool Create(const bool exclusive = false)
         {
-            return (Create(USER_READ|USER_WRITE|USER_EXECUTE|GROUP_READ|GROUP_EXECUTE), exclusive);
+            return (Create((USER_READ|USER_WRITE|USER_EXECUTE|GROUP_READ|GROUP_EXECUTE), exclusive));
         }
 
         bool Create(const uint32_t mode, const bool exclusive = false)


### PR DESCRIPTION
File::Create(const bool) had problems with parentheses, so instead of returning result of File::Create(const uint32_t, const bool) it was returning "exclusive" value.

This caused problems with storing config in Controller plugin and seemed to be crashing WebKitBrowser.