### PR TITLE
[SerialPort] Fixed file closing being made to early & locking problems

### DIFF
--- a/Source/bluetooth/HCISocket.cpp
+++ b/Source/bluetooth/HCISocket.cpp
@@ -378,7 +378,7 @@ void HCISocket::Abort()
         }
 
         if ((name == nullptr) || (pos == 0)) {
-            TRACE_L1("Entry[%s] has no name.", Address(advertisingInfo->bdaddr).ToString());
+            TRACE_L1("Entry[%s] has no name.", Address(advertisingInfo->bdaddr).ToString().c_str());
             Discovered(false, Address(advertisingInfo->bdaddr), _T("[Unknown]"));
         } else {
             Discovered(true, Address(advertisingInfo->bdaddr), string(name, pos));

--- a/Source/core/SerialPort.cpp
+++ b/Source/core/SerialPort.cpp
@@ -645,14 +645,8 @@ namespace Core {
             // subscribtion.
             m_State |= SerialPort::EXCEPTION;
             m_State &= ~SerialPort::OPEN;
-            close(m_Descriptor);
-            m_Descriptor = -1;
             ResourceMonitor::Instance().Break();
-
-            m_syncAdmin.Unlock();
-
-            WaitForClosure(waitTime);
-        } else {
+        } 
 #endif
 
 #ifdef __WIN32__
@@ -660,21 +654,15 @@ namespace Core {
 
                 m_State |= SerialPort::EXCEPTION;
                 m_State &= ~SerialPort::OPEN;
-                ::CloseHandle(m_Descriptor);
-                m_Descriptor = INVALID_HANDLE_VALUE;
                 g_SerialPortMonitor.Break();
-
-                m_syncAdmin.Unlock();
-
-                WaitForClosure(waitTime);
-            } else {
+            } 
 #endif
 
-                m_syncAdmin.Unlock();
-            }
+        WaitForClosure(waitTime);
+        m_syncAdmin.Unlock();
 
-            return (Core::ERROR_NONE);
-        }
+        return (Core::ERROR_NONE);
+    }
 
         uint32_t SerialPort::WaitForClosure(const uint32_t time) const
         {

--- a/Source/core/SerialPort.h
+++ b/Source/core/SerialPort.h
@@ -243,6 +243,17 @@ namespace Core {
         void Closed()
         {
             StateChange();
+
+#ifdef __LINUX__
+            close(m_Descriptor);
+            m_Descriptor = -1;
+#endif
+
+#ifdef __WIN32__
+            ::CloseHandle(m_Descriptor);
+            m_Descriptor = INVALID_HANDLE_VALUE;
+#endif
+
             m_State = 0;
         }
         uint32_t WaitForClosure(const uint32_t time) const;


### PR DESCRIPTION
Moved actual closing of file to closed() rather than close(). This fixes problems with file descriptor being invalidated too quickly. 

Also fixed minor problems with locking