### PR TITLE
Fix incomplete conversion from avc to bytestream format for multiple …

### DIFF
--- a/Source/ocdm/adapter/broadcom-svp/open_cdm_adapter.cpp
+++ b/Source/ocdm/adapter/broadcom-svp/open_cdm_adapter.cpp
@@ -45,11 +45,12 @@ static void addSVPMetaData(GstBuffer* gstBuffer, uint8_t* opaqueData)
     gst_buffer_add_brcm_svp_meta(gstBuffer, svpMeta);
 }
 
-static void replaceLengthPrefixWithStartcodePrefix(uint8_t* buffer, size_t size)
+static void replaceLengthPrefixWithStartCodePrefix(uint8_t* buffer, size_t size)
 {
-    uint8_t* curr;
-    uint8_t* end;
-    uint32_t remain, slice_size = 0;
+    uint8_t* curr = NULL;
+    uint8_t* end = NULL;
+    uint32_t remain = 0;
+    uint32_t slice_size = 0;
 
     curr =  buffer;
     end = buffer + size;
@@ -159,7 +160,7 @@ OpenCDMError opencdm_gstreamer_session_decrypt(struct OpenCDMSession* session, G
 
                 assert( sizeof(nalUnit) < (inClear+inEncrypted));
                 // replace length prefiex NALU length into startcode prefix
-                replaceLengthPrefixWithStartcodePrefix(mappedData+index, inClear+inEncrypted);
+                replaceLengthPrefixWithStartCodePrefix(mappedData+index, inClear+inEncrypted);
                 B_Secbuf_ImportData(opaqueDataEnc, index, mappedData + index, inClear + inEncrypted, true);
                 index += inClear + inEncrypted;
             }


### PR DESCRIPTION
qtdemux downstreams in "avc" stream-format in which NAL units are seperated by length. For clear stream, brcmvidfilter convert the length field into start codes. However, in SVP mode, CPU is not able to access decrypted data and the length should be replaced by start codes for BRCM decoder. So sample data conversion takes place here. 

But the code is incomplete to handle multiple NALs. Which converts only the first one. It results in continuous broken pictures at playing some YouTube contents;(https://youtu.be/ja_QElCv30k)
