### PR TITLE
WebSerializer: Don't treat PNG as binary.

### DIFF
--- a/Source/websocket/WebSerializer.cpp
+++ b/Source/websocket/WebSerializer.cpp
@@ -306,7 +306,6 @@ namespace Web
     } extensionLookupTable[] = {
         { Web::MIME_HTML, _TXT("html") },
         { Web::MIME_HTML, _TXT("htm") },
-        { Web::MIME_BINARY, _TXT("png") },
         { Web::MIME_JSON, _TXT("json") },
         { Web::MIME_CSS, _TXT("css") },
         { Web::MIME_IMAGE_TIFF, _TXT("tif") },


### PR DESCRIPTION
This fixes an issue where WebServer returns PNG with incorrect content-type "Content-Type: application/octet-stream". There is a duplicate entry below that returns the correct PNG content type.