### PR TITLE
[Json] Added escaping of special characters in json string,

### DIFF
--- a/Tests/core/CMakeLists.txt
+++ b/Tests/core/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(${TEST_RUNNER_NAME}
    ../IPTestAdministrator.cpp
    test_rpc.cpp
    test_jsonparser.cpp
+   test_jsonserializer.cpp
 #   test_sharedbuffer.cpp
 )
 

--- a/Tests/core/test_jsonparser.cpp
+++ b/Tests/core/test_jsonparser.cpp
@@ -517,11 +517,11 @@ namespace Tests {
         TestData data;
         data.key = "key";
         data.keyToPutInJson = "\"" + data.key + "\"";
-        const char rawUnescaped[] = { 'v', 'a', 'l', 'u', 'e', ' ', '"', '\b', '\n', '\f', '\r', '\\', 'u', '0', '0', 'b', '1', '/', '\\', '\0' };
+        const char rawUnescaped[] = { 'v', 'a', 'l', 'u', 'e', ' ', '"', '\b', '\n', '\f', '\r', 0xb1, '/', '\\', '\0' };
         data.value = "value \\\"\\b\\n\\f\\r\\u00b1\\/\\\\";
         data.valueToPutInJson = "\"" + data.value + "\"";
         ExecutePrimitiveJsonTest<Core::JSON::String>(data, true, [rawUnescaped](const Core::JSON::String& v) {
-            EXPECT_TRUE(memcmp(rawUnescaped, v.Value().c_str(), sizeof(rawUnescaped)) == 0);
+            EXPECT_EQ(v.Value(), rawUnescaped);
         });
     }
 

--- a/Tests/core/test_jsonserializer.cpp
+++ b/Tests/core/test_jsonserializer.cpp
@@ -1,0 +1,62 @@
+#include <functional>
+#include <sstream>
+#include <gtest/gtest.h>
+#include "JSON.h"
+
+using namespace WPEFramework::Core;
+
+TEST(JSONStringSerialization, EscapeCharacters)
+{
+    JSON::String json_string;
+    json_string = "\"\\\b\f\n\r\t/";
+    string jsonified_string;
+
+    json_string.ToString(jsonified_string);
+
+    EXPECT_EQ(jsonified_string, "\"\\\"\\\\\\b\\f\\n\\r\\t\\/\"");
+}
+
+TEST(JSONStringSerialization, EscapeNonPrintable) {
+    string example = {static_cast<char>(1), static_cast<char>(127)};
+    string serialized;
+
+    JSON::String json;
+    json = example;
+
+    json.ToString(serialized);
+
+    EXPECT_EQ(serialized, "\"\\u0001\\u007f\"");
+}
+
+TEST(JSONStringSerialization, SerializationIsReversable) {
+    const string example = "{\"test\":123,\"test2\":\"123\x02\"}";
+    string serialized;
+
+    JSON::String json;
+    json = example;
+
+    json.ToString(serialized);
+    json.FromString(serialized);
+
+    EXPECT_EQ(json.Value(), example); 
+}
+
+TEST(JSONStringSerialization, MultipleSerializationIsReversable) {
+    const string example = "{\"test\":123,\"test2\":\"123\x02\"}";
+    string serialized;
+    string unserialized;
+
+    JSON::String json;
+    json = example;
+
+    json.ToString(serialized);
+    json = serialized;
+    json.ToString(serialized);
+
+    json.FromString(serialized);
+    unserialized = json.Value();
+    json.FromString(unserialized);
+    unserialized = json.Value();
+
+    EXPECT_EQ(unserialized, example); 
+}


### PR DESCRIPTION
Escaping is done according to RFC 7159. Now WebKit should have no problems with deserializing json strings 
This change is followup of Jira ticket WPE-320 (Unescaped json)