### PR TITLE
[JSON] Added Hex and Oct Test Cases to JSONParser test and fixed issu…

### DIFF
--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -494,7 +494,7 @@ namespace Core {
                             offset = 2;
                         } else if (stream[loaded] == '-') {
                             _set |= NEGATIVE;
-                            offset = 3;
+                            offset = 2;
                         } else if (isdigit(stream[loaded])) {
                             _value = (stream[loaded] - '0');
                             _set |= DECIMAL;
@@ -515,7 +515,7 @@ namespace Core {
                             _set |= HEXADECIMAL;
                         } else if (isdigit(stream[loaded])) {
                             _value = (stream[loaded] - '0');
-                            _set = (_set & NEGATIVE ? DECIMAL : OCTAL);
+                            _set |= (_set & NEGATIVE ? DECIMAL : OCTAL);
                             offset = 4;
                         } else if (((_set & UNDEFINED) != 0) && (stream[loaded] == 'l')) {
                             offset = 3;

--- a/Tests/core/test_jsonparser.cpp
+++ b/Tests/core/test_jsonparser.cpp
@@ -492,6 +492,54 @@ namespace Tests {
         });
     }
 
+    TEST(JSONParser, PositiveHexNumber)
+    {
+        TestData data;
+        data.key = "key";
+        data.keyToPutInJson = "\"" + data.key + "\"";
+        data.value = "0X7B";
+        data.valueToPutInJson = "\"" + data.value + "\"";;
+        ExecutePrimitiveJsonTest<Core::JSON::HexUInt8>(data, true, [](const Core::JSON::HexUInt8& v) {
+            EXPECT_EQ(123u, v.Value());
+        });
+    }
+
+    TEST(JSONParser, NegativeHexNumber)
+    {
+        TestData data;
+        data.key = "key";
+        data.keyToPutInJson = "\"" + data.key + "\"";
+        data.value = "-0X7B";
+        data.valueToPutInJson = "\"" + data.value + "\"";;
+        ExecutePrimitiveJsonTest<Core::JSON::HexSInt8>(data, true, [](const Core::JSON::HexSInt8& v) {
+            EXPECT_EQ(-123, v.Value());
+        });
+    }
+
+    TEST(JSONParser, PositiveOctNumber)
+    {
+        TestData data;
+        data.key = "key";
+        data.keyToPutInJson = "\"" + data.key + "\"";
+        data.value = "0173";
+        data.valueToPutInJson = "\"" + data.value + "\"";;
+        ExecutePrimitiveJsonTest<Core::JSON::OctUInt8>(data, true, [](const Core::JSON::OctUInt8& v) {
+            EXPECT_EQ(123u, v.Value());
+        });
+    }
+
+    TEST(JSONParser, NegativeOctNumber)
+    {
+        TestData data;
+        data.key = "key";
+        data.keyToPutInJson = "\"" + data.key + "\"";
+        data.value = "-0173";
+        data.valueToPutInJson = "\"" + data.value + "\"";;
+        ExecutePrimitiveJsonTest<Core::JSON::OctSInt8>(data, true, [](const Core::JSON::OctSInt8& v) {
+            EXPECT_EQ(-123, v.Value());
+        });
+    }
+
     // FIXME: Disabled because JSON Parser does not support exponential notation
     // yet is supports hex so 'E' or 'e' in number is interpreted as hex.
     TEST(DISABLED_JSONParser, ExponentialNumber)


### PR DESCRIPTION
1. Added Hexadecimal and Octal parsing tests to JSONParser Test.
2. Fixed issued in Hexadecimal and Octal parsing in core JSON.h.