### PR TITLE
[OCDM] Skip unnecessary decrypt.

### DIFF
--- a/Source/ocdm/open_cdm.cpp
+++ b/Source/ocdm/open_cdm.cpp
@@ -368,8 +368,8 @@ OpenCDMError opencdm_session_decrypt(struct OpenCDMSession* session,
     OpenCDMError result(ERROR_INVALID_SESSION);
 
     if (session != nullptr) {
-        result = static_cast<OpenCDMError>(session->Decrypt(
-            encrypted, encryptedLength, IV, IVLength, keyId, keyIdLength, initWithLast15));
+        result = encryptedLength > 0 ? static_cast<OpenCDMError>(session->Decrypt(
+            encrypted, encryptedLength, IV, IVLength, keyId, keyIdLength, initWithLast15)) : ERROR_NONE;
     }
 
     return (result);


### PR DESCRIPTION
It may cause error being returned from a CDM.