### PR TITLE
[Compositorclient: Wayland]: nullptr changed to NULL to handle castin…

### DIFF
--- a/Source/compositorclient/Wayland/Westeros.cpp
+++ b/Source/compositorclient/Wayland/Westeros.cpp
@@ -653,7 +653,7 @@ namespace Wayland {
                     _eglSurfaceWindow = eglCreateWindowSurface(
                         _display->_eglDisplay,
                         _display->_eglConfig,
-                        static_cast<EGLNativeWindowType>(nullptr),
+                        reinterpret_cast<EGLNativeWindowType>(NULL),
                         nullptr);
                 }
 

--- a/Source/compositorclient/Wayland/Westeros.cpp
+++ b/Source/compositorclient/Wayland/Westeros.cpp
@@ -653,7 +653,8 @@ namespace Wayland {
                     _eglSurfaceWindow = eglCreateWindowSurface(
                         _display->_eglDisplay,
                         _display->_eglConfig,
-                        reinterpret_cast<EGLNativeWindowType>(NULL),
+                        reinterpret_cast<EGLNativeWindowType>(NULL), // Kept it as NULL to support casting to both pointer and non pointer type,
+                                                                     // based on the EGLNativeWindowType provided by the platform
                         nullptr);
                 }
 


### PR DESCRIPTION
…g to EGLNativeWindowType (pointer and nonpointer types)

The actual type of EGLNativeWindowType is pointer or non pointer based on the platform used. So if we use the nullptr to do the casting, it always expect the casting to a pointer type only. As per the issue: https://github.com/WebPlatformForEmbedded/Thunder/issues/212, here the EGLNativeWindowType is 'long unsigned int', but in api build root case, it is void*. So I think better to use NULL, instead of nullptr.