### PR TITLE
[Thread] Fix for proper destruction without hangs.

### DIFF
--- a/Source/core/Thread.h
+++ b/Source/core/Thread.h
@@ -457,9 +457,6 @@ namespace Core {
                     // Yield the processor, just to make sure that the gap, between the comparison
                     // of the Executing(.....) ended up in the lock, before we pulse it :-)
                     ::SleepMs(0);
-
-                    // Do not wait keep on processing !!!
-                    return (0);
                 }
 
                 // Oops queue disabled, wait for queue to start us again..


### PR DESCRIPTION
Since the thread is not waiting here
https://github.com/WebPlatformForEmbedded/Thunder/blob/87966d6b7be079a2d8d2cccf52f28f17eac3cd67/Source/core/Thread.cpp#L157
because of delayed = 0, its showing undefined behaviour on destruction sometimes (hang or call of destructed class Worker function) . Added fix for that.