### PR TITLE
Compositor:RPI: clear keyboard/mouse/touch pointers only after closin…

### DIFF
--- a/Source/compositorclient/RPI/Implementation.cpp
+++ b/Source/compositorclient/RPI/Implementation.cpp
@@ -393,13 +393,13 @@ private:
         write(g_pipefd[1], &message, sizeof(message));
         close(g_pipefd[1]);
 
-        callback_keyboard(nullptr);
-        callback_mouse(nullptr);
-        callback_touch(nullptr);
-
         if (_virtualinput != nullptr) {
             virtualinput_close(_virtualinput);
         }
+
+        callback_keyboard(nullptr);
+        callback_mouse(nullptr);
+        callback_touch(nullptr);
 
         std::list<SurfaceImplementation*>::iterator index(_surfaces.begin());
         while (index != _surfaces.end()) {


### PR DESCRIPTION
…g the vitualinput, it is required to ensure all unregister of handlers done properly