### PR TITLE
[OCDM] Send only encrypted chunks for decryption also in SVP path.

### DIFF
--- a/Source/ocdm/adapter/broadcom-svp/open_cdm_adapter.cpp
+++ b/Source/ocdm/adapter/broadcom-svp/open_cdm_adapter.cpp
@@ -14,8 +14,6 @@ struct RPCSecureBufferInformation {
     size_t size;
     void* token;
     void* token_enc;
-    uint32_t subSamplesCount;
-    uint32_t subSamples[]; // Array of clear and encrypted pairs of subsamples.
 };
 
 static const uint8_t nalUnit[] = {0x00, 0x00, 0x00, 0x01};
@@ -33,56 +31,6 @@ inline bool mappedBuffer(GstBuffer *buffer, bool writable, uint8_t **data, uint3
     gst_buffer_unmap (buffer, &map);
 
     return true;
-}
-
-static void addSVPMetaData(GstBuffer* gstBuffer, uint8_t* opaqueData)
-{
-    brcm_svp_meta_data_t* svpMeta = reinterpret_cast<brcm_svp_meta_data_t*> (g_malloc0(sizeof(brcm_svp_meta_data_t)));
-    assert(svpMeta);
-
-    svpMeta->sub_type = GST_META_BRCM_SVP_TYPE_1;
-    svpMeta->u.u1.secbuf_ptr = reinterpret_cast<unsigned>(opaqueData);
-    gst_buffer_add_brcm_svp_meta(gstBuffer, svpMeta);
-}
-
-static void replaceLengthPrefixWithStartCodePrefix(uint8_t* buffer, size_t size)
-{
-    uint8_t* curr = NULL;
-    uint8_t* end = NULL;
-    uint32_t remain = 0;
-    uint32_t slice_size = 0;
-
-    curr =  buffer;
-    end = buffer + size;
-    remain = size;
-
-    while (curr < end) {
-
-        slice_size = (*curr) << 24;
-        slice_size += (*(curr + 1)) << 16;
-        slice_size += (*(curr + 2)) << 8;
-        slice_size += (*(curr + 3)) ;
-
-        if ((curr == buffer) && 
-                (*curr       == nalUnit[0]) && 
-                (*(curr + 1) == nalUnit[1]) && 
-                (*(curr + 2) == nalUnit[2]) && 
-                (*(curr + 3) == nalUnit[3])) {
-            return;
-        }
-
-        if (slice_size > remain) {
-            return;
-        }
-
-        *curr       = nalUnit[0];
-        *(curr + 1) = nalUnit[1];
-        *(curr + 2) = nalUnit[2];
-        *(curr + 3) = nalUnit[3];
-
-        curr   += slice_size + sizeof(nalUnit);
-        remain -= slice_size + sizeof(nalUnit);
-    }
 }
 
 OpenCDMError opencdm_gstreamer_session_decrypt(struct OpenCDMSession* session, GstBuffer* buffer, GstBuffer* subSample, const uint32_t subSampleCount,
@@ -131,12 +79,32 @@ OpenCDMError opencdm_gstreamer_session_decrypt(struct OpenCDMSession* session, G
         B_Secbuf_Info secureBufferInfo;
         void *opaqueData, *opaqueDataEnc;
 
-        // If there is no subsample, only allocate one region for clear+enc, otherwise, number of subsamples.
-        uint32_t rpcSubSampleTotalSize = (subSampleCount ? subSampleCount * 2 : 2) * sizeof(uint32_t);
-        uint32_t sizeOfRPCInfo = sizeof(RPCSecureBufferInformation) + rpcSubSampleTotalSize;
+        uint32_t sizeOfRPCInfo = sizeof(RPCSecureBufferInformation);
         RPCSecureBufferInformation* rpcSecureBufferInformation = reinterpret_cast<RPCSecureBufferInformation*> (g_alloca(sizeOfRPCInfo));
 
-        if(B_Secbuf_Alloc(mappedDataSize, B_Secbuf_Type_eGeneric, &opaqueDataEnc)) {
+        uint32_t bufferSize = mappedDataSize;
+
+        if (mappedSubSample) {
+            GstByteReader* reader = gst_byte_reader_new(mappedSubSample, mappedSubSampleSize);
+            uint16_t inClear = 0;
+            uint32_t inEncrypted = 0;
+            uint32_t totalEncrypted = 0;
+            for (unsigned int position = 0; position < subSampleCount; position++) {
+                gst_byte_reader_get_uint16_be(reader, &inClear);
+                gst_byte_reader_get_uint32_be(reader, &inEncrypted);
+                totalEncrypted += inEncrypted;
+            }
+            gst_byte_reader_free(reader);
+
+            if (totalEncrypted == 0) {
+                result = ERROR_NONE;
+                goto exit;
+            }
+
+            bufferSize = totalEncrypted;
+        }
+
+        if(B_Secbuf_Alloc(bufferSize, B_Secbuf_Type_eGeneric, &opaqueDataEnc)) {
             TRACE_L1("adapter_session_decrypt: Secbuf alloc failed!");
             result = ERROR_INVALID_DECRYPT_BUFFER;
             goto exit;
@@ -148,34 +116,31 @@ OpenCDMError opencdm_gstreamer_session_decrypt(struct OpenCDMSession* session, G
         rpcSecureBufferInformation->token_enc = secureBufferInfo.token;
         rpcSecureBufferInformation->token     = NULL;
 
-        if (mappedSubSample) {
+        brcm_svp_meta_data_t* svpMeta = static_cast<brcm_svp_meta_data_t *>(g_malloc(sizeof(brcm_svp_meta_data_t)));
+        memset(svpMeta, 0, sizeof(brcm_svp_meta_data_t));
+        svpMeta->sub_type = GST_META_BRCM_SVP_TYPE_2;
+        svpMeta->u.u2.chunks_cnt = subSampleCount > 0 ? subSampleCount : 1;
+        svpMeta->u.u2.chunk_info = static_cast<svp_chunk_info *>(g_malloc(svpMeta->u.u2.chunks_cnt * sizeof(svp_chunk_info)));
 
+        if (mappedSubSample) {
             GstByteReader* reader = gst_byte_reader_new(mappedSubSample, mappedSubSampleSize);
             uint16_t inClear = 0;
             uint32_t inEncrypted = 0;
-            for (unsigned int position = 0, index = 0; position < subSampleCount; position++) {
+            for (uint32_t indexSec = 0, indexClr = 0, position = 0; position < subSampleCount; position++) {
                 gst_byte_reader_get_uint16_be(reader, &inClear);
                 gst_byte_reader_get_uint32_be(reader, &inEncrypted);
 
-                rpcSecureBufferInformation->subSamples[2*position] = static_cast<uint32_t>(inClear);
-                rpcSecureBufferInformation->subSamples[2*position + 1] = inEncrypted;
-
-                assert( sizeof(nalUnit) < (inClear+inEncrypted));
-                // replace length prefiex NALU length into startcode prefix
-                replaceLengthPrefixWithStartCodePrefix(mappedData+index, inClear+inEncrypted);
-                B_Secbuf_ImportData(opaqueDataEnc, index, mappedData + index, inClear + inEncrypted, true);
-                index += inClear + inEncrypted;
+                B_Secbuf_ImportData(opaqueDataEnc, indexSec, mappedData + indexClr + inClear, inEncrypted, true);
+                svpMeta->u.u2.chunk_info[position].clear_size = inClear;
+                svpMeta->u.u2.chunk_info[position].encrypted_size = inEncrypted;
+                indexSec += inEncrypted;
+                indexClr += inClear + inEncrypted;
             }
             gst_byte_reader_free(reader);
-
-            rpcSecureBufferInformation->subSamplesCount = subSampleCount * 2; // In order of clear+enc+clear+enc...
         } else {
-
+            svpMeta->u.u2.chunk_info[0].clear_size = 0;
+            svpMeta->u.u2.chunk_info[0].encrypted_size = mappedDataSize;
             B_Secbuf_ImportData(opaqueDataEnc, 0, mappedData, mappedDataSize, true);
-
-            rpcSecureBufferInformation->subSamples[0] = 0; // No clear.
-            rpcSecureBufferInformation->subSamples[1] = mappedDataSize; // All encrypted.
-            rpcSecureBufferInformation->subSamplesCount = 2; // One pair of clear_enc.
         }
         // opaqueDataEnc no need as more. OCDM will acces it via its token
         B_Secbuf_FreeDesc(opaqueDataEnc);
@@ -187,13 +152,14 @@ OpenCDMError opencdm_gstreamer_session_decrypt(struct OpenCDMSession* session, G
         }
 
         // OCDM allocate opaqueData for secure decrypted buffer and will be freed in gstreamer
-        if(B_Secbuf_AllocWithToken(mappedDataSize, B_Secbuf_Type_eSecure,  rpcSecureBufferInformation->token, &opaqueData)) {
+        if(B_Secbuf_AllocWithToken(bufferSize, B_Secbuf_Type_eSecure,  rpcSecureBufferInformation->token, &opaqueData)) {
             TRACE_L1("adapter_session_decrypt: Secbuf Alloc failed!");
             result = ERROR_INVALID_DECRYPT_BUFFER;
             goto exit;
         }
 
-        addSVPMetaData(buffer, reinterpret_cast<uint8_t*>(opaqueData));
+        svpMeta->u.u1.secbuf_ptr = reinterpret_cast<uintptr_t>(opaqueData);
+        gst_buffer_add_brcm_svp_meta(buffer, svpMeta);
     }
 exit:
     return (result);

--- a/Source/ocdm/adapter/broadcom-svp/open_cdm_adapter.cpp
+++ b/Source/ocdm/adapter/broadcom-svp/open_cdm_adapter.cpp
@@ -158,7 +158,7 @@ OpenCDMError opencdm_gstreamer_session_decrypt(struct OpenCDMSession* session, G
             goto exit;
         }
 
-        svpMeta->u.u1.secbuf_ptr = reinterpret_cast<uintptr_t>(opaqueData);
+        svpMeta->u.u2.secbuf_ptr = reinterpret_cast<uintptr_t>(opaqueData);
         gst_buffer_add_brcm_svp_meta(buffer, svpMeta);
     }
 exit:


### PR DESCRIPTION
This aligns SVP adapter with the non-SVP one. Instead of
sending clear+enc+clear+enc+clear+enc+... subsamples to the DRM send only
encrypted ones. This also moves reponsibilty for proper subsamples handling
to GST part.