### PR TITLE
[CORE] Fixes stack reporting.

### DIFF
--- a/Source/core/Portability.cpp
+++ b/Source/core/Portability.cpp
@@ -65,32 +65,15 @@ static void* GetPCFromUContext(void* secret)
 
 static void OverrideStackTopWithPC(void** stack, int stackSize, void* secret)
 {
-    bool foundNull = false;
-
-    int i;
-    for (i = 0; i < stackSize; i++) {
-        void* ptr = stack[i];
-
-        if (ptr != nullptr && foundNull) {
-            // Found first non-null entry.
-            --i;
-            break;
-        } else if (ptr == nullptr) {
-            foundNull = true;
-        }
-    }
-
-    if (i == stackSize) {
-        return;
-    }
-
-    stack[i] = GetPCFromUContext(secret);
-
-    // Remove unneeded stack entries.
-    memmove(stack, stack + i, sizeof(void*) * (stackSize - i));
+    // Move all stack entries one to the right, make sure not to write beyond buffer.
+    uint32_t movedCount = std::min(stackSize, g_threadCallstackBufferSize - 1);
+    memmove(stack + 1, stack, sizeof(void*) * movedCount);
 
     // Set rest to zeroes.
-    memset(stack + stackSize - i, 0, sizeof(void*) * i);
+    memset(stack + 1 + movedCount, 0, sizeof(void*) * (g_threadCallstackBufferSize - movedCount - 1));
+
+    // Assign PC to first entry.
+    stack[0] = GetPCFromUContext(secret);
 }
 
 static void CallstackSignalHandler(int signr VARIABLE_IS_NOT_USED, siginfo_t* info VARIABLE_IS_NOT_USED, void* secret)


### PR DESCRIPTION
Callstack grows left-to-right in array, with top of the stack (without current PC) on index 0. So we need to move all entries to the right and put PC at the beginning.
Credit @anjalirajan for reporting issue.