### PR TITLE
IKeyProducer: Add: Sink class for notifications

### DIFF
--- a/Source/interfaces/IKeyHandler.h
+++ b/Source/interfaces/IKeyHandler.h
@@ -71,6 +71,25 @@ namespace Exchange {
         virtual uint32_t Error() const = 0;
         virtual string MetaData() const = 0;
         virtual void Configure(const string& settings) = 0;
+
+        enum KeyProducerEvents
+        {
+            ePairingStarted,
+            ePairingSuccess,
+            ePairingFailed,
+            ePairingTimedout
+        };
+
+        struct INotification : virtual public IUnknown {
+            enum {ID = ID_KEYPRODUCER_NOTIFICATION};
+
+            virtual ~INotification()
+            {
+            }
+
+            virtual void KeyProducerEvent(const KeyProducerEvents) = 0;
+        };
+
     };
 
     struct IWheelProducer : virtual public Core::IUnknown {

--- a/Source/interfaces/Ids.h
+++ b/Source/interfaces/Ids.h
@@ -111,7 +111,9 @@ namespace Exchange {
         ID_TOUCHPRODUCER,
 
         ID_STREAM_ELEMENT,
-        ID_STREAM_ELEMENT_ITERATOR
+        ID_STREAM_ELEMENT_ITERATOR,
+
+        ID_KEYPRODUCER_NOTIFICATION
     };
 }
 }


### PR DESCRIPTION
This commit adds a new Sink class in IKeyProducer for getting events
about pairing states in other plugins.

The events considered now are:
ePairingStarted
ePairingSuccess
ePairingFailed
ePairingTimedout

Signed-off-by: harikrishnan.p <harikris2012@gmail.com>