### PR TITLE
Global: Fixes from NOS testing

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -53,6 +53,27 @@ option(STUB_HARDWARE
 option(BUILD_TYPE
         "How do you want to build it, Production, Release or Debug" Production)
 
+#
+# Build type specific options
+#
+if(NOT BUILD_TYPE)
+    set(BUILD_TYPE Production)
+    message(AUTHOR_WARNING "BUILD_TYPE not set, assuming '${BUILD_TYPE}'")
+endif()
+if("${BUILD_TYPE}" STREQUAL "Debug")
+    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build." FORCE)
+elseif("${BUILD_TYPE}" STREQUAL "DebugOptimized")
+    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build." FORCE)
+elseif("${BUILD_TYPE}" STREQUAL "ReleaseSymbols")
+    set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Choose the type of build." FORCE)
+elseif("${BUILD_TYPE}" STREQUAL "Release")
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
+elseif("${BUILD_TYPE}" STREQUAL "Production")
+    set(CMAKE_BUILD_TYPE "MinSizeRel" CACHE STRING "Choose the type of build." FORCE)
+else()
+    message(FATAL_ERROR "Invalid BUILD_TYPE: '${BUILD_TYPE}'")
+endif()
+
 set(EXTERN_EVENTS ${EXTERN_EVENTS} CACHE INTERNAL
         "List of events assumed to be provided by other plugins.")
 string(REPLACE " " ";" EXTERN_EVENT_LIST "${EXTERN_EVENTS}")

--- a/Source/core/CMakeLists.txt
+++ b/Source/core/CMakeLists.txt
@@ -155,6 +155,7 @@ target_link_libraries(${TARGET}
         PUBLIC
           CompileSettings::CompileSettings
         PRIVATE
+          CompileSettingsDebug::CompileSettingsDebug
           ${CMAKE_DL_LIBS}
 	  ${LIBEXECINFO_LIBRARY}
           LIBRT::LIBRT
@@ -196,7 +197,7 @@ endif()
 # Install ARTIFACTS:
 # ===========================================================================================
 install(
-        TARGETS CompileSettings ${TARGET}  EXPORT ${TARGET}Targets  # for downstream dependencies
+        TARGETS CompileSettings CompileSettingsDebug ${TARGET}  EXPORT ${TARGET}Targets  # for downstream dependencies
         ARCHIVE DESTINATION lib COMPONENT libs      # static lib
         LIBRARY DESTINATION lib COMPONENT libs      # shared lib
         RUNTIME DESTINATION bin COMPONENT libs      # binaries

--- a/cmake/CompileSettings.cmake
+++ b/cmake/CompileSettings.cmake
@@ -7,6 +7,9 @@ option(POSITION_INDEPENDENT_CODE "Create position independent code on all target
 add_library(CompileSettings INTERFACE)
 add_library(CompileSettings::CompileSettings ALIAS CompileSettings)
 
+add_library(CompileSettingsDebug INTERFACE)
+add_library(CompileSettingsDebug::CompileSettingsDebug ALIAS CompileSettingsDebug)
+
 #
 # Global options
 #
@@ -37,33 +40,28 @@ target_compile_options(CompileSettings INTERFACE -std=c++11 -Wno-psabi)
 # Build type specific options
 #
 if("${BUILD_TYPE}" STREQUAL "Debug")
-    target_compile_definitions(CompileSettings INTERFACE _DEBUG)
+    target_compile_definitions(CompileSettingsDebug INTERFACE _DEBUG)
     set(CONFIG_DIR "Debug" CACHE STRING "Build config directory" FORCE)
-    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build." FORCE)
 
 elseif("${BUILD_TYPE}" STREQUAL "DebugOptimized")
-    target_compile_definitions(CompileSettings INTERFACE _DEBUG)
+    target_compile_definitions(CompileSettingsDebug INTERFACE _DEBUG)
     set(CONFIG_DIR "DebugOptimized" CACHE STRING "Build config directory" FORCE)
-    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build." FORCE)
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR ${CMAKE_COMPILER_IS_GNUCXX} )
-        target_compile_options(CompileSettings INTERFACE -g)
+        target_compile_options(CompileSettingsDebug INTERFACE -g)
     endif()
 
 elseif("${BUILD_TYPE}" STREQUAL "ReleaseSymbols")
-    target_compile_definitions(CompileSettings INTERFACE NDEBUG)
+    target_compile_definitions(CompileSettingsDebug INTERFACE NDEBUG)
     set(CONFIG_DIR "ReleaseSymbols" CACHE STRING "Build config directory" FORCE)
-    set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Choose the type of build." FORCE)
-    target_compile_options(CompileSettings INTERFACE "${CMAKE_C_FLAGS_DEBUG}")
+    target_compile_options(CompileSettingsDebug INTERFACE "${CMAKE_C_FLAGS_DEBUG}")
 
 elseif("${BUILD_TYPE}" STREQUAL "Release")
     set(CONFIG_DIR "Release" CACHE STRING "Build config directory" FORCE)
-    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
-    target_compile_definitions(CompileSettings INTERFACE NDEBUG)
+    target_compile_definitions(CompileSettingsDebug INTERFACE NDEBUG)
 
 elseif("${BUILD_TYPE}" STREQUAL "Production")
     set(CONFIG_DIR "Production" CACHE STRING "Build config directory" FORCE)
-    set(CMAKE_BUILD_TYPE "MinSizeRel" CACHE STRING "Choose the type of build." FORCE)
-    target_compile_definitions(CompileSettings INTERFACE NDEBUG PRODUCTION)
+    target_compile_definitions(CompileSettingsDebug INTERFACE NDEBUG PRODUCTION)
 
 else()
     message(FATAL_ERROR "Invalid BUILD_TYPE: '${BUILD_TYPE}'")

--- a/cmake/project.cmake.in
+++ b/cmake/project.cmake.in
@@ -18,21 +18,8 @@ endif()
 # installation dir of cmakepp
 
 set(NAMESPACE "@NAMESPACE@")
-set(BUILD_TYPE "@BUILD_TYPE@")
 
 set(JSON_GENERATOR "@JSON_GENERATOR@")
-
-if("${BUILD_TYPE}" STREQUAL "DebugOptimized" OR "${BUILD_TYPE}" STREQUAL "Debug")
-    set(CMAKE_BUILD_TYPE "Debug")
-elseif("${BUILD_TYPE}" STREQUAL "ReleaseSymbols")
-    set(CMAKE_BUILD_TYPE "RelWithDebInfo")
-elseif("${BUILD_TYPE}" STREQUAL "Release")
-    set(CMAKE_BUILD_TYPE "Release")
-elseif("${BUILD_TYPE}" STREQUAL "Production")
-    set(CMAKE_BUILD_TYPE "MinSizeRel")
-else()
-    message(AUTHOR_WARNING "Unknown BUILD_TYPE: '${BUILD_TYPE}'")
-endif()
 
 set(MODULE_BASE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 


### PR DESCRIPTION
A few thunder fixes and changes drafted after NOS testing with the latest framework.

Commit 1 fixes the exported cmake files (to be used by other projects - e.g. plugins - depending on thunder), so that cmake debug related options used for thunder are not imposed on the projects importing thunder.

All of the fixes and changes are required for correct operation of Thunder under the use cases required by NOS.