### PR TITLE
[VIRTUALINPUT] Remove the KeyRepeatTimer watchdog thread. (Resource r…

### DIFF
--- a/Source/plugins/VirtualInput.cpp
+++ b/Source/plugins/VirtualInput.cpp
@@ -18,7 +18,7 @@ ENUM_CONVERSION_BEGIN(PluginHost::VirtualInput::KeyMap::modifier)
 
 namespace PluginHost
 {
-    /*static */ VirtualInput* InputHandler::_keyHandler;
+    /* static */ VirtualInput* InputHandler::_keyHandler;
 
     uint32_t VirtualInput::KeyMap::Load(const string& keyMap)
     {
@@ -173,7 +173,7 @@ namespace PluginHost
 #endif
     VirtualInput::VirtualInput()
         : _lock()
-        , _repeatKey(*this)
+        , _repeatKey(this)
         , _modifiers(0)
         , _defaultMap(nullptr)
         , _notifierMap()
@@ -182,6 +182,7 @@ namespace PluginHost
         , _repeatLimit(0)
     {
         // The derived class shoud set, the initial value of the modifiers...
+        _repeatKey.AddRef();
     }
 #ifdef __WIN32__
 #pragma warning(default : 4355)
@@ -190,6 +191,8 @@ namespace PluginHost
     VirtualInput::~VirtualInput()
     {
         _mappingTables.clear();
+        _repeatKey.DropReference();
+        _repeatKey.CompositRelease();
     }
 
     void VirtualInput::Register(INotifier * callback, const uint32_t keyCode)
@@ -657,12 +660,17 @@ namespace PluginHost
 #endif
 
     // Keyboard input
-
+#ifdef __WIN32__
+#pragma warning(disable : 4355)
+#endif
     IPCUserInput::IPCUserInput(const Core::NodeId& sourceName)
         : _service(*this, sourceName)
     {
         TRACE_L1("Constructing IPCUserInput for %s on %s", sourceName.HostAddress().c_str(), sourceName.HostName().c_str());
     }
+#ifdef __WIN32__
+#pragma warning(default : 4355)
+#endif
 
     /* virtual */ IPCUserInput::~IPCUserInput()
     {

--- a/Source/plugins/VirtualInput.h
+++ b/Source/plugins/VirtualInput.h
@@ -25,8 +25,6 @@ namespace PluginHost {
             RepeatKeyTimer(const RepeatKeyTimer&) = delete;
             RepeatKeyTimer& operator=(const RepeatKeyTimer&) = delete;
 
-            static constexpr uint32_t RepeatStackSize = 64 * 1024;
-
         public:
 #ifdef __WIN32__
 #pragma warning(disable : 4355)
@@ -364,7 +362,7 @@ namespace PluginHost {
         virtual ~VirtualInput();
 
     public:
-		inline void RepeatLimit(uint16_t limit)
+	inline void RepeatLimit(const uint16_t limit)
         {
             _repeatLimit = limit;
         }


### PR DESCRIPTION
…eduction)
I ran into this additional thread as this was not compiling on windows using the latest VS2019 compiler. The reference of the KeyRepeatTimer in the watchdog now needed a copy or assignment operator for a part of the template not used (VS2019 got stricter) in stead of fixing that issue (compiletime diffrentation) I chose to remove the thread as this is not needed with the WorkerPool (and timer functionality)