### PR TITLE
[ThreadPool] Allow configuring THREADPOOL_COUNT in build time

### DIFF
--- a/Source/WPEFramework/CMakeLists.txt
+++ b/Source/WPEFramework/CMakeLists.txt
@@ -1,5 +1,7 @@
 get_filename_component(TARGET ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
+set(THREADPOOL_COUNT 4 CACHE STRING "The number of threads in the thread pool")
+
 add_executable(${TARGET}
         Controller.cpp
         ControllerJsonRpc.cpp
@@ -13,7 +15,7 @@ target_compile_definitions(${TARGET}
         PRIVATE
           NAMESPACE=${NAMESPACE}
           APPLICATION_NAME=${TARGET}
-          THREADPOOL_COUNT=4
+          THREADPOOL_COUNT=${THREADPOOL_COUNT}
         )
 
 if (TREE_REFERENCE)


### PR DESCRIPTION
Allow configuring the THREADPOOL_COUNT in build time, which represents
the number of threads in the thread pool. Do this by exporting it via a
cmake variable with the same name and with its default value set to 4,
which was the previous hardcoded value (keeps backward compatibility).

In some use cases, namely when there are a lot of OOP plugins, during
startup the framework reaches states where all the threads in the pool
are already busy waiting for responses, etc., but those responses
themselves need a thread from the pool to complete and release the other
waiting threads. In some cases (depends on startup timings, etc.), no
more threads are available and responses start to fail, timeouts
reached, etc. The visible result is that some OOP plugins fail to
launch. These cases can only be solved by having more threads available,
at least during the startup.

So far, the number of threads cannot be managed dynamically. It would be
interesting to allow more threads during startup and then maybe reduce
that limit after startup is done, i.e., have some dynamic management for
the number of threads in the pool. However, since this can ow only be
managed in build time, start by at least allowing a configurable limit
in build time, using a cmake variable.

Signed-off-by: Ricardo Silva <ricardo.silva@gbtembedded.com>