### PR TITLE
[DEBUG] Install SIGSEGV signal handler only for debug builds

### DIFF
--- a/Source/WPEFramework/PluginHost.cpp
+++ b/Source/WPEFramework/PluginHost.cpp
@@ -318,7 +318,9 @@ namespace PluginHost {
 
             sigaction(SIGINT, &sa, nullptr);
             sigaction(SIGTERM, &sa, nullptr);
+#ifdef __DEBUG__
             sigaction(SIGSEGV, &sa, nullptr);
+#endif
             sigaction(SIGQUIT, &sa, nullptr);
         }
 

--- a/Source/WPEProcess/Process.cpp
+++ b/Source/WPEProcess/Process.cpp
@@ -364,7 +364,9 @@ int main(int argc, char** argv)
 
             sigaction(SIGINT, &sa, nullptr);
             sigaction(SIGTERM, &sa, nullptr);
+#ifdef __DEBUG__
             sigaction(SIGSEGV, &sa, nullptr);
+#endif
             sigaction(SIGQUIT, &sa, nullptr);
 #endif
     }


### PR DESCRIPTION
The signal handler for SIGSEGV was being installed unconditionally,
which prevents using other debug external tools (e.g. google's breakpad)
for debugging.

This way, install the signal handler for SIGSEGV only for debug builds.

Signed-off-by: Ricardo Silva <ricardo.silva@gbtembedded.com>