### PR TITLE
OCDM: release ocdm system after use

### DIFF
--- a/Source/ocdm/open_cdm_impl.h
+++ b/Source/ocdm/open_cdm_impl.h
@@ -87,8 +87,6 @@ public:
         } else {
             // Reconnect if server is down
             _singleton->Reconnect();
-
-            _singleton->AddRef();
         }
 
         _systemLock.Unlock();
@@ -510,6 +508,7 @@ public:
             Session(nullptr);
         }
 
+        system->Release();
         TRACE_L1("Destructed the Session Client side: %p", this);
     }
 


### PR DESCRIPTION
Seems we are not releasing OpenCDMAccessor class after use, so added support