### PR TITLE
Only sets GENERIC_CMAKE_MODULE_PATH if not passed via command line.

### DIFF
--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -6,11 +6,13 @@ set(GENERATOR_INSTALL_PATH "${CMAKE_INSTALL_PREFIX}/sbin")
 
 message("CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SYSTEM_PREFIX_PATH}, CMAKE_SYSTEM_LIBRARY_PATH ${CMAKE_SYSTEM_LIBRARY_PATH}, CMAKE_SYSTEM_INCLUDE_PATH ${CMAKE_SYSTEM_INCLUDE_PATH} and CMAKE_SYSTEM_PROGRAM_PATH ${CMAKE_SYSTEM_PROGRAM_PATH}")
 
-find_path(GENERIC_CMAKE_MODULE_PATH CMake.cmake
-    PATHS
-        "/usr/share/cmake/Modules/"
-        "/usr/share/cmake-${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}/Modules/"
-)
+if(NOT DEFINED GENERIC_CMAKE_MODULE_PATH)
+   find_path(GENERIC_CMAKE_MODULE_PATH CMake.cmake
+       PATHS
+           "/usr/share/cmake/Modules/"
+           "/usr/share/cmake-${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}/Modules/"
+   )
+endif()
 
 configure_file( "${CMAKE_SOURCE_DIR}/cmake/FindProxyStubGenerator.cmake.in"
                 "${CMAKE_CURRENT_BINARY_DIR}/FindProxyStubGenerator.cmake"


### PR DESCRIPTION
This fixes the desktop (PC) build of WPEFramework