### PR TITLE
[PROXY] Depending on the Proxy Object, make sure the proper lifetime …

### DIFF
--- a/Source/core/Portability.h
+++ b/Source/core/Portability.h
@@ -554,13 +554,11 @@ namespace Core {
         virtual uint32_t Release() const = 0;
     };
 
-    struct EXTERNAL IUnknown {
+    struct EXTERNAL IUnknown : public IReferenceCounted  {
         enum { ID = 0x00000000 };
 
         virtual ~IUnknown(){};
 
-        virtual void AddRef() const = 0;
-        virtual uint32_t Release() const = 0;
         virtual void* QueryInterface(const uint32_t interfaceNummer) = 0;
 
         template <typename REQUESTEDINTERFACE>

--- a/Source/core/Services.h
+++ b/Source/core/Services.h
@@ -9,6 +9,7 @@
 #include "Sync.h"
 #include "TextFragment.h"
 #include "Trace.h"
+#include "Proxy.h"
 
 namespace WPEFramework {
 namespace Core {
@@ -81,151 +82,31 @@ namespace Core {
         Service<ACTUALSERVICE> operator=(const Service<ACTUALSERVICE>&) = delete;
 
     protected:
-        Service()
-            : ACTUALSERVICE()
-            , _referenceCount(0)
-        {
-            ServiceAdministrator::Instance().AddRef();
-        }
-        template <typename ARG1>
-        Service(ARG1 arg1)
-            : ACTUALSERVICE(arg1)
-            , _referenceCount(0)
-        {
-            ServiceAdministrator::Instance().AddRef();
-        }
-        template <typename ARG1, typename ARG2>
-        Service(ARG1 arg1, ARG2 arg2)
-            : ACTUALSERVICE(arg1, arg2)
-            , _referenceCount(0)
-        {
-            ServiceAdministrator::Instance().AddRef();
-        }
-        template <typename ARG1, typename ARG2, typename ARG3>
-        Service(ARG1 arg1, ARG2 arg2, ARG3 arg3)
-            : ACTUALSERVICE(arg1, arg2, arg3)
-            , _referenceCount(0)
-        {
-            ServiceAdministrator::Instance().AddRef();
-        }
-        template <typename ARG1, typename ARG2, typename ARG3, typename ARG4>
-        Service(ARG1 arg1, ARG2 arg2, ARG3 arg3, ARG4 arg4)
-            : ACTUALSERVICE(arg1, arg2, arg3, arg4)
-            , _referenceCount(0)
-        {
-            ServiceAdministrator::Instance().AddRef();
-        }
-        template <typename ARG1, typename ARG2, typename ARG3, typename ARG4, typename ARG5>
-        Service(ARG1 arg1, ARG2 arg2, ARG3 arg3, ARG4 arg4, ARG5 arg5)
-            : ACTUALSERVICE(arg1, arg2, arg3, arg4, arg5)
-            , _referenceCount(0)
-        {
-            ServiceAdministrator::Instance().AddRef();
-        }
-        template <typename ARG1, typename ARG2, typename ARG3, typename ARG4, typename ARG5, typename ARG6>
-        Service(ARG1 arg1, ARG2 arg2, ARG3 arg3, ARG4 arg4, ARG5 arg5, ARG6 arg6)
-            : ACTUALSERVICE(arg1, arg2, arg3, arg4, arg5, arg6)
-            , _referenceCount(0)
-        {
-            ServiceAdministrator::Instance().AddRef();
-        }
-        template <typename ARG1, typename ARG2, typename ARG3, typename ARG4, typename ARG5, typename ARG6, typename ARG7>
-        Service(ARG1 arg1, ARG2 arg2, ARG3 arg3, ARG4 arg4, ARG5 arg5, ARG6 arg6, ARG7 arg7)
-            : ACTUALSERVICE(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
-            , _referenceCount(0)
-        {
-            ServiceAdministrator::Instance().AddRef();
-        }
-        template <typename ARG1, typename ARG2, typename ARG3, typename ARG4, typename ARG5, typename ARG6, typename ARG7, typename ARG8>
-        Service(ARG1 arg1, ARG2 arg2, ARG3 arg3, ARG4 arg4, ARG5 arg5, ARG6 arg6, ARG7 arg7, ARG8 arg8)
-            : ACTUALSERVICE(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
-            , _referenceCount(0)
+        template<typename... Args>
+        Service(Args... args)
+            : ACTUALSERVICE(std::forward<Args>(args)...)
         {
             ServiceAdministrator::Instance().AddRef();
         }
 
     public:
-        template <typename INTERFACE>
-        static INTERFACE* Create()
-        {
-            ACTUALSERVICE* object = new Service();
+        //template <typename INTERFACE>
+        //static INTERFACE* Create()
+        //{
+        //    ACTUALSERVICE* object = new (0) ProxyService<CONTEXT>();
 
-            return (Extract<INTERFACE>(object, TemplateIntToType<std::is_same<ACTUALSERVICE, INTERFACE>::value>()));
-        }
-        template <typename INTERFACE, typename ARG1>
-        static INTERFACE* Create(ARG1 arg1)
+        //    return (Extract<INTERFACE>(object, TemplateIntToType<std::is_same<ACTUALSERVICE, INTERFACE>::value>()));
+        //}
+        template <typename INTERFACE, typename... Args>
+        static INTERFACE* Create(Args... args)
         {
-            ACTUALSERVICE* object = new Service(arg1);
-
-            return (Extract<INTERFACE>(object, TemplateIntToType<std::is_same<ACTUALSERVICE, INTERFACE>::value>()));
-        }
-        template <typename INTERFACE, typename ARG1, typename ARG2>
-        static INTERFACE* Create(ARG1 arg1, ARG2 arg2)
-        {
-            ACTUALSERVICE* object = new Service(arg1, arg2);
-
-            return (Extract<INTERFACE>(object, TemplateIntToType<std::is_same<ACTUALSERVICE, INTERFACE>::value>()));
-        }
-        template <typename INTERFACE, typename ARG1, typename ARG2, typename ARG3>
-        static INTERFACE* Create(ARG1 arg1, ARG2 arg2, ARG3 arg3)
-        {
-            ACTUALSERVICE* object = new Service(arg1, arg2, arg3);
-
-            return (Extract<INTERFACE>(object, TemplateIntToType<std::is_same<ACTUALSERVICE, INTERFACE>::value>()));
-        }
-        template <typename INTERFACE, typename ARG1, typename ARG2, typename ARG3, typename ARG4>
-        static INTERFACE* Create(ARG1 arg1, ARG2 arg2, ARG3 arg3, ARG4 arg4)
-        {
-            ACTUALSERVICE* object = new Service(arg1, arg2, arg3, arg4);
-
-            return (Extract<INTERFACE>(object, TemplateIntToType<std::is_same<ACTUALSERVICE, INTERFACE>::value>()));
-        }
-        template <typename INTERFACE, typename ARG1, typename ARG2, typename ARG3, typename ARG4, typename ARG5>
-        static INTERFACE* Create(ARG1 arg1, ARG2 arg2, ARG3 arg3, ARG4 arg4, ARG5 arg5)
-        {
-            ACTUALSERVICE* object = new Service(arg1, arg2, arg3, arg4, arg5);
-
-            return (Extract<INTERFACE>(object, TemplateIntToType<std::is_same<ACTUALSERVICE, INTERFACE>::value>()));
-        }
-        template <typename INTERFACE, typename ARG1, typename ARG2, typename ARG3, typename ARG4, typename ARG5, typename ARG6>
-        static INTERFACE* Create(ARG1 arg1, ARG2 arg2, ARG3 arg3, ARG4 arg4, ARG5 arg5, ARG6 arg6)
-        {
-            ACTUALSERVICE* object = new Service(arg1, arg2, arg3, arg4, arg5, arg6);
-
-            return (Extract<INTERFACE>(object, TemplateIntToType<std::is_same<ACTUALSERVICE, INTERFACE>::value>()));
-        }
-        template <typename INTERFACE, typename ARG1, typename ARG2, typename ARG3, typename ARG4, typename ARG5, typename ARG6, typename ARG7>
-        static INTERFACE* Create(ARG1 arg1, ARG2 arg2, ARG3 arg3, ARG4 arg4, ARG5 arg5, ARG6 arg6, ARG7 arg7)
-        {
-            ACTUALSERVICE* object = new Service(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
-
-            return (Extract<INTERFACE>(object, TemplateIntToType<std::is_same<ACTUALSERVICE, INTERFACE>::value>()));
-        }
-        template <typename INTERFACE, typename ARG1, typename ARG2, typename ARG3, typename ARG4, typename ARG5, typename ARG6, typename ARG7, typename ARG8>
-        static INTERFACE* Create(ARG1 arg1, ARG2 arg2, ARG3 arg3, ARG4 arg4, ARG5 arg5, ARG6 arg6, ARG7 arg7, ARG8 arg8)
-        {
-            ACTUALSERVICE* object = new Service(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+            ACTUALSERVICE* object = new (0) ProxyService<ACTUALSERVICE>(std::forward<Args>(args)...);
 
             return (Extract<INTERFACE>(object, TemplateIntToType<std::is_same<ACTUALSERVICE, INTERFACE>::value>()));
         }
         virtual ~Service()
         {
             ServiceAdministrator::Instance().Release();
-        }
-
-    public:
-        virtual void AddRef() const
-        {
-            Core::InterlockedIncrement(_referenceCount);
-        }
-        virtual uint32_t Release() const
-        {
-            if (Core::InterlockedDecrement(_referenceCount) == 0) {
-                delete this;
-
-                return (Core::ERROR_DESTRUCTION_SUCCEEDED);
-            }
-            return (Core::ERROR_NONE);
         }
 
     private:
@@ -246,9 +127,6 @@ namespace Core {
             object->AddRef();
             return (object);
         }
-
-    private:
-        mutable uint32_t _referenceCount;
     };
 
     template <typename ACTUALSINK>
@@ -258,20 +136,9 @@ namespace Core {
         Sink<ACTUALSINK> operator=(const Sink<ACTUALSINK>&) = delete;
 
     public:
-        Sink()
-            : ACTUALSINK()
-            , _referenceCount(0)
-        {
-        }
-        template <typename ARG1>
-        Sink(ARG1 arg1)
-            : ACTUALSINK(arg1)
-            , _referenceCount(0)
-        {
-        }
-        template <typename ARG1, typename ARG2>
-        Sink(ARG1 arg1, ARG2 arg2)
-            : ACTUALSINK(arg1, arg2)
+        template <typename... Args>
+        Sink(Args... args)
+            : ACTUALSINK(std::forward<Args>(args)...)
             , _referenceCount(0)
         {
         }
@@ -355,7 +222,7 @@ namespace Core {
         virtual void* Create(const Library& library, const uint32_t interfaceNumber)
         {
             void* result = nullptr;
-            IUnknown* object = new ServiceImplementation<ACTUALSERVICE>(library);
+            IUnknown* object = new (0) ProxyService< ServiceImplementation<ACTUALSERVICE> >(library);
 
             if (object != nullptr) {
                 // This quety interface will increment the refcount of the Service at least to 1.

--- a/Source/plugins/plugins.vcxproj.filters
+++ b/Source/plugins/plugins.vcxproj.filters
@@ -86,6 +86,9 @@
     <ClInclude Include="VirtualInput.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="IRemoteInstantiation.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Text Include="CMakeLists.txt" />


### PR DESCRIPTION
…management interface is added.

If a COM interface is part of the Proxy object, Lifetime is managed by the IUnknown (IReferenceCounted base) interface, so the ProxyObject should not be created with an additional IReferenceCounted interface. So do not add it to the ProxyObject.
If it a s none IReferenceCounted inheriting object, there is aneed to add this interface to the object. So using type traits make sure teh ProxyObject is created diffrently.