### PR TITLE
Weston and Westeros wayland pointer support

### DIFF
--- a/Source/compositorclient/Wayland/Implementation.h
+++ b/Source/compositorclient/Wayland/Implementation.h
@@ -47,9 +47,6 @@ namespace Wayland {
             virtual void Attached(const uint32_t id) = 0;
             virtual void Detached(const uint32_t id) = 0;
         };
-        struct IPointer {
-            virtual ~IPointer() {}
-        };
 
     private:
         Display();
@@ -744,6 +741,30 @@ namespace Wayland {
             }
 
             _adminLock.Unlock();
+        }
+
+        void SendPointerPosition(const uint16_t x, const uint16_t y)
+        {
+            _adminLock.Lock();
+
+            if ((_pointerReceiver != nullptr) && (_pointerReceiver->_pointer != nullptr)) {
+              _pointerReceiver->_pointer->Direct(x, y);
+            }
+
+            _adminLock.Unlock();
+
+        }
+
+        void SendPointerButton(const uint8_t button, const IPointer::state action)
+        {
+            _adminLock.Lock();
+
+            if ((_pointerReceiver != nullptr) && (_pointerReceiver->_pointer != nullptr)) {
+              _pointerReceiver->_pointer->Direct(button, action);
+            }
+
+            _adminLock.Unlock();
+
         }
 
         // Wayland related info

--- a/Source/compositorclient/Wayland/Westeros.cpp
+++ b/Source/compositorclient/Wayland/Westeros.cpp
@@ -185,15 +185,26 @@ static const struct wl_pointer_listener pointerListener = {
     // pointerMotion
     [](void* data, struct wl_pointer* pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy) {
         int x, y;
+        Wayland::Display& context = *(static_cast<Wayland::Display*>(data));
 
         x = wl_fixed_to_int(sx);
         y = wl_fixed_to_int(sy);
 
         Trace("wl_pointer_listener.pointerMotion [%d,%d]\n", x, y);
+        context.SendPointerPosition(x, y);
     },
     // pointerButton
     [](void* data, struct wl_pointer* pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state) {
+        Wayland::Display& context = *(static_cast<Wayland::Display*>(data));
         Trace("wl_pointer_listener.pointerButton [%u,%u]\n", button, state);
+
+        //align with what WPEBackend-rdk wpeframework backend is expecting
+        if (button >= BTN_MOUSE)
+          button = button - BTN_MOUSE;
+        else
+          button = 0;
+
+        context.SendPointerButton(button, static_cast<Wayland::Display::IPointer::state>(state));
     },
     // pointerAxis
     [](void* data, struct wl_pointer* pointer, uint32_t time, uint32_t axis, wl_fixed_t value) {

--- a/Source/compositorclient/Wayland/Weston.cpp
+++ b/Source/compositorclient/Wayland/Weston.cpp
@@ -182,15 +182,26 @@ static const struct wl_pointer_listener pointerListener = {
     // pointerMotion
     [](void* data, struct wl_pointer* pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy) {
         int x, y;
+        Wayland::Display& context = *(static_cast<Wayland::Display*>(data));
 
         x = wl_fixed_to_int(sx);
         y = wl_fixed_to_int(sy);
 
         Trace("wl_pointer_listener.pointerMotion [%d,%d]\n", x, y);
+        context.SendPointerPosition(x, y);
     },
     // pointerButton
     [](void* data, struct wl_pointer* pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state) {
+        Wayland::Display& context = *(static_cast<Wayland::Display*>(data));
         Trace("wl_pointer_listener.pointerButton [%u,%u]\n", button, state);
+
+        //align with what WPEBackend-rdk wpeframework backend is expecting
+        if (button >= BTN_MOUSE)
+          button = button - BTN_MOUSE;
+        else
+          button = 0;
+
+        context.SendPointerButton(button, static_cast<Wayland::Display::IPointer::state>(state));
     },
     // pointerAxis
     [](void* data, struct wl_pointer* pointer, uint32_t time, uint32_t axis, wl_fixed_t value) {

--- a/cmake/modules/FindWestonClient.cmake
+++ b/cmake/modules/FindWestonClient.cmake
@@ -31,17 +31,15 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 find_package(PkgConfig)
-pkg_check_modules(PC_WESTON weston-compositor)
+pkg_check_modules(PC_WESTON weston)
 
-find_library(WESTON_CLIENT_LIB NAMES weston-desktop-5
+find_library(WESTON_CLIENT_LIB NAMES weston-desktop-5 weston-desktop-6
         HINTS ${PC_WESTON_LIBDIR} ${PC_WESTON_LIBRARY_DIRS}
 )
 
 set (WESTON_CLIENT_LIBRARIES ${PC_WESTON_LIBRARIES})
 
-set (WESTON_CLIENT_FOUND TRUE)
-
-if(WESTON_CLIENT_FOUND AND NOT TARGET WestonClient::WestonClient)
+if(PC_WESTON_FOUND AND NOT TARGET WestonClient::WestonClient)
     set(WESTON_CLIENT_LIB_CLIENT_LINK_LIBRARIES "${WESTON_CLIENT_LIB}")
     add_library(WestonClient::WestonClient UNKNOWN IMPORTED)
     set_target_properties(WestonClient::WestonClient PROPERTIES
@@ -54,6 +52,6 @@ if(WESTON_CLIENT_FOUND AND NOT TARGET WestonClient::WestonClient)
 endif()
 
 include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(PC_WESTON DEFAULT_MSG WESTON_CLIENT_FOUND)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(PC_WESTON DEFAULT_MSG PC_WESTON_FOUND)
 
 mark_as_advanced(WESTON_CLIENT_LIBRARIES)


### PR DESCRIPTION
This pull request glues the Wayland pointer events in Weston.cpp and Westeros.cpp to the wpebackend-rdk when configured with wpeframework packageconfig. With these commits applied it is then possible to use the pointer to drive the web browser (previously only keyboard was functional).

There are also some fixes to FindWestonClient.cmake file.

