### PR TITLE
Fix for OCDMImplementation process not closing correctly.

### DIFF
--- a/Source/core/Thread.cpp
+++ b/Source/core/Thread.cpp
@@ -182,12 +182,9 @@ namespace Core {
         // Report that the worker is done by releasing the Signal sync mechanism.
         cClassPointer->m_sigExit.SetEvent();
 
-#ifdef __POSIX__
-        ::pthread_exit(nullptr);
+#ifndef __WINDOWS__
         return (nullptr);
-#endif
-
-#ifdef __WINDOWS__
+#else 
         ::ExitThread(0);
 #endif
     }


### PR DESCRIPTION
The cause of the problem was identified as a possible bug within glibc. After the dlclose call, a chain of destructors gets called, which ends up being a 'pthread_join' call on a thread that has called 'pthread_exit' some time beforehand. This problem has been already noticed in previous glibc versions, with a bug report [available here.](https://bugs.launchpad.net/ubuntu/+source/eglibc/+bug/775374) It seems that either, the bug was not fixed, or this is expected behaviour.

Within that bug report, you can find a minimal working example that illustrates the issue, however the Makefile contents weren't valid. Here's the correct version:
```[makefile]

CC=gcc -g

APP_LDFLAGS = -ldl
LIB_LDFLAGS = -shared

APP_OBJS=main.o
LIB_OBJS=TestMod.o

APP:=join_test
LIB:=libTestMod.so

CFLAGS= -c -fPIC
APPLDFLAGS= -pthread $(APP_LDFLAGS)
LIBLDFLAGS= -pthread $(LIB_LDFLAGS)

all: $(LIB) $(APP)

$(LIB): $(LIB_OBJS)
	$(CC) $(LIBLDFLAGS) $(LIB_OBJS) -o $(LIB)

$(APP): $(APP_OBJS)
	$(CC) $(APP_OBJS) -o $(APP) $(APPLDFLAGS)

%.o : %.c
	$(CC) $(CFLAGS) -o $@ $<

clean:
	rm -f $(LIB_OBJS) $(LIB) $(APP_OBJS) $(APP) *~*
	

```