### PR TITLE
[Threading] WorkerPool Revoke() now guarantees job is not running anymore

### DIFF
--- a/Source/com/Administrator.h
+++ b/Source/com/Administrator.h
@@ -248,7 +248,7 @@ namespace RPC {
         {
             return (_factory.Element());
         }
-        void Clear()
+        void Dispose()
         {
             _message.Release();
             _channel.Release();

--- a/Source/core/Thread.h
+++ b/Source/core/Thread.h
@@ -444,7 +444,7 @@ namespace Core {
                     _executing.Dispatch();
 
                     // Clear it out, we processed it.
-                    _executing = RUNCONTEXT();
+                    _executing.Dispose();
 
                     _active = false;
                     _run++;

--- a/Source/core/WorkerPool.cpp
+++ b/Source/core/WorkerPool.cpp
@@ -16,12 +16,16 @@ namespace WPEFramework {
 			_metadata.Slots = threadCount;
 			_metadata.Slot = counters;
 			_instance = this;
+
+			_workerStatuses = new WorkerStatus[threadCount];
 		}
 
 		WorkerPool ::~WorkerPool()
 		{
 			_handleQueue.Disable();
 			_instance = nullptr;
+
+			delete[] _workerStatuses;
 		}
 	}
 }


### PR DESCRIPTION
Forces Revoke() method of workerpool to wait in case the job is running at the moment. Fixes potential problems with hard to reproduce timing-based bugs

