### PR TITLE
[VirtualInput] Fix iteration in LookupChanges()

### DIFF
--- a/Source/plugins/VirtualInput.cpp
+++ b/Source/plugins/VirtualInput.cpp
@@ -728,13 +728,13 @@ namespace PluginHost
     /* virtual */ void IPCUserInput::LookupChanges(const string& linkName)
     {
         uint16_t index = 0;
-        Core::ProxyType<InputDataLink> current(_service[index++]);
+        Core::ProxyType<Core::IPCChannelClientType<InputDataLink, false, false>> current(_service[index++]);
 
         while (current.IsValid() == true) {
-            if (current->Name() == linkName) {
-                current->Reload();
+            if (current->Extension().Name() == linkName) {
+                current->Extension().Reload();
             }
-            current = Core::ProxyType<InputDataLink>(_service[index++]);
+            current = Core::ProxyType<Core::IPCChannelClientType<InputDataLink, false, false>>(_service[index++]);
         }
     }
 


### PR DESCRIPTION
When a Post Lookup map for a given link name (callsign) is registered in
the virtual input, IPCUserInput::LookupChanges() is called to search for
existing IPC Clients with names matching that link name, so those
clients post lookup map gets updated with the newly registered one.

This is required for the use cases where there are already IPC clients
registered when the post lookup map is registered (e.g. by the
RemoteControl plugin), or when a post lookup map is changed.

The way LookupChanges() is iterating over the registered IPC Clients is
incorrect. In particular the 'current' object type, declared as follows,
is wrong:

    'Core::ProxyType<InputDataLink> current'

It's wrong because '_service[]' returns an entry in the client map which
is instead of type:

    'Core::ProxyType<Core::IPCChannelClientType<InputDataLink, false, false>> current'

Due to the polymorphic nature of proxies, etc., this is not detected
in build time, only in runtime, where, although it's confirmed that the
client map has one or more IPC Clients, 'current' is always being
returned as 'nullptr' due to 'dynamic_cast' failure to convert between
the actual/correct type and the incorrectly declared type for 'current'.

Fix this by using the correct declaration for 'current'.
Since 'current' is actually a 'Core::IPCChannelClientType<InputDataLink,
false, false>' object, to get to the InputDataLink object (so Name() and
Reload() can be used) it's required to use 'current->Extension()', so
adjust accordingly.

Signed-off-by: Ricardo Silva <ricardo.silva@gbtembedded.com>