### PR TITLE
wpeframework : Replacing stime() with clocksettime() in SystemInfo.cp…

### DIFF
--- a/Source/core/SystemInfo.cpp
+++ b/Source/core/SystemInfo.cpp
@@ -323,7 +323,17 @@ namespace Core {
 
         time_t value = mktimegm(&setTime);
 
+#if defined(__GNU_LIBRARY__)
+  #if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ > 30)
+        timespec ts = {};
+        ts.tv_sec = value;
+        if (clock_settime(CLOCK_REALTIME, &ts) != 0){
+  #else
         if (stime(&value) != 0) {
+  #endif
+#else
+        if (stime(&value) != 0) {
+#endif
             TRACE_L1("Failed to set system time [%d]", errno);
         } else {
             TRACE_L1("System time updated [%d]", errno);


### PR DESCRIPTION
…p as GLIBC moved to 2.31

As the GLIBC moved to 2.31 from 2.30 the stime() was removed in 2.31 and
it throws error while building wpeframework in SystemInfo.cpp.So replacing the
stime() with clocksesttime().

Signed-off-by: balav08 <balaji.velmurugan@ltts.com>