### PR TITLE
Adjusted JsonGenerator & ProxyStubGenerator to work with Python 3.5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 A C++ platform abstraction layer for generic functionality.
 
+### Thunder dependencies
+After the JsonGenerator.py and StubGenerator.py were modified to run with the python 3.5 version, some action might be required. When using buildroot or yocto, no action is necessary. Upon running these scripts manually or on Windows, make sure python 3.5 or higher is used, like so:
+```Shell
+$ python --version
+```
+You might also need to fulfill a requirement of the **jsonref** library, with the following line:
+```Shell
+$ pip install jsonref
+``` 
+
 ### Thunder Options
 **Platforms:**
 * INTELCE

--- a/Tools/.style.yapf
+++ b/Tools/.style.yapf
@@ -1,0 +1,358 @@
+[style]
+
+# Align closing bracket with visual indentation.
+align_closing_bracket_with_visual_indent=True
+
+# Allow dictionary keys to exist on multiple lines. For example:
+#
+#   x = {
+#       ('this is the first element of a tuple',
+#        'this is the second element of a tuple'):
+#            value,
+#   }
+allow_multiline_dictionary_keys=False
+
+# Allow lambdas to be formatted on more than one line.
+allow_multiline_lambdas=False
+
+# Allow splitting before a default / named assignment in an argument list.
+allow_split_before_default_or_named_assigns=True
+
+# Allow splits before the dictionary value.
+allow_split_before_dict_value=True
+
+#   Let spacing indicate operator precedence. For example:
+#
+#     a = 1 * 2 + 3 / 4
+#     b = 1 / 2 - 3 * 4
+#     c = (1 + 2) * (3 - 4)
+#     d = (1 - 2) / (3 + 4)
+#     e = 1 * 2 - 3
+#     f = 1 + 2 + 3 + 4
+#
+# will be formatted as follows to indicate precedence:
+#
+#     a = 1*2 + 3/4
+#     b = 1/2 - 3*4
+#     c = (1+2) * (3-4)
+#     d = (1-2) / (3+4)
+#     e = 1*2 - 3
+#     f = 1 + 2 + 3 + 4
+#
+arithmetic_precedence_indication=False
+
+# Number of blank lines surrounding top-level function and class
+# definitions.
+blank_lines_around_top_level_definition=2
+
+# Insert a blank line before a class-level docstring.
+blank_line_before_class_docstring=False
+
+# Insert a blank line before a module docstring.
+blank_line_before_module_docstring=False
+
+# Insert a blank line before a 'def' or 'class' immediately nested
+# within another 'def' or 'class'. For example:
+#
+#   class Foo:
+#                      # <------ this blank line
+#     def method():
+#       ...
+blank_line_before_nested_class_or_def=False
+
+# Do not split consecutive brackets. Only relevant when
+# dedent_closing_brackets is set. For example:
+#
+#    call_func_that_takes_a_dict(
+#        {
+#            'key1': 'value1',
+#            'key2': 'value2',
+#        }
+#    )
+#
+# would reformat to:
+#
+#    call_func_that_takes_a_dict({
+#        'key1': 'value1',
+#        'key2': 'value2',
+#    })
+coalesce_brackets=False
+
+# The column limit.
+column_limit=79
+
+# The style for continuation alignment. Possible values are:
+#
+# - SPACE: Use spaces for continuation alignment. This is default behavior.
+# - FIXED: Use fixed number (CONTINUATION_INDENT_WIDTH) of columns
+#   (ie: CONTINUATION_INDENT_WIDTH/INDENT_WIDTH tabs) for continuation
+#   alignment.
+# - VALIGN-RIGHT: Vertically align continuation lines with indent
+#   characters. Slightly right (one more indent character) if cannot
+#   vertically align continuation lines with indent characters.
+#
+# For options FIXED, and VALIGN-RIGHT are only available when USE_TABS is
+# enabled.
+continuation_align_style=SPACE
+
+# Indent width used for line continuations.
+continuation_indent_width=4
+
+# Put closing brackets on a separate line, dedented, if the bracketed
+# expression can't fit in a single line. Applies to all kinds of brackets,
+# including function definitions and calls. For example:
+#
+#   config = {
+#       'key1': 'value1',
+#       'key2': 'value2',
+#   }        # <--- this bracket is dedented and on a separate line
+#
+#   time_series = self.remote_client.query_entity_counters(
+#       entity='dev3246.region1',
+#       key='dns.query_latency_tcp',
+#       transform=Transformation.AVERAGE(window=timedelta(seconds=60)),
+#       start_ts=now()-timedelta(days=3),
+#       end_ts=now(),
+#   )        # <--- this bracket is dedented and on a separate line
+dedent_closing_brackets=False
+
+# Disable the heuristic which places each list element on a separate line
+# if the list is comma-terminated.
+disable_ending_comma_heuristic=False
+
+# Place each dictionary entry onto its own line.
+each_dict_entry_on_separate_line=True
+
+# The regex for an i18n comment. The presence of this comment stops
+# reformatting of that line, because the comments are required to be
+# next to the string they translate.
+i18n_comment=
+
+# The i18n function call names. The presence of this function stops
+# reformattting on that line, because the string it has cannot be moved
+# away from the i18n comment.
+i18n_function_call=
+
+# Indent blank lines.
+indent_blank_lines=False
+
+# Put closing brackets on a separate line, indented, if the bracketed
+# expression can't fit in a single line. Applies to all kinds of brackets,
+# including function definitions and calls. For example:
+#
+#   config = {
+#       'key1': 'value1',
+#       'key2': 'value2',
+#       }        # <--- this bracket is indented and on a separate line
+#
+#   time_series = self.remote_client.query_entity_counters(
+#       entity='dev3246.region1',
+#       key='dns.query_latency_tcp',
+#       transform=Transformation.AVERAGE(window=timedelta(seconds=60)),
+#       start_ts=now()-timedelta(days=3),
+#       end_ts=now(),
+#       )        # <--- this bracket is indented and on a separate line
+indent_closing_brackets=False
+
+# Indent the dictionary value if it cannot fit on the same line as the
+# dictionary key. For example:
+#
+#   config = {
+#       'key1':
+#           'value1',
+#       'key2': value1 +
+#               value2,
+#   }
+indent_dictionary_value=False
+
+# The number of columns to use for indentation.
+indent_width=4
+
+# Join short lines into one line. E.g., single line 'if' statements.
+join_multiple_lines=True
+
+# Do not include spaces around selected binary operators. For example:
+#
+#   1 + 2 * 3 - 4 / 5
+#
+# will be formatted as follows when configured with "*,/":
+#
+#   1 + 2*3 - 4/5
+no_spaces_around_selected_binary_operators=
+
+# Use spaces around default or named assigns.
+spaces_around_default_or_named_assign=False
+
+# Use spaces around the power operator.
+spaces_around_power_operator=False
+
+# The number of spaces required before a trailing comment.
+# This can be a single value (representing the number of spaces
+# before each trailing comment) or list of values (representing
+# alignment column values; trailing comments within a block will
+# be aligned to the first column value that is greater than the maximum
+# line length within the block). For example:
+#
+# With spaces_before_comment=5:
+#
+#   1 + 1 # Adding values
+#
+# will be formatted as:
+#
+#   1 + 1     # Adding values <-- 5 spaces between the end of the statement and comment
+#
+# With spaces_before_comment=15, 20:
+#
+#   1 + 1 # Adding values
+#   two + two # More adding
+#
+#   longer_statement # This is a longer statement
+#   short # This is a shorter statement
+#
+#   a_very_long_statement_that_extends_beyond_the_final_column # Comment
+#   short # This is a shorter statement
+#
+# will be formatted as:
+#
+#   1 + 1          # Adding values <-- end of line comments in block aligned to col 15
+#   two + two      # More adding
+#
+#   longer_statement    # This is a longer statement <-- end of line comments in block aligned to col 20
+#   short               # This is a shorter statement
+#
+#   a_very_long_statement_that_extends_beyond_the_final_column  # Comment <-- the end of line comments are aligned based on the line length
+#   short                                                       # This is a shorter statement
+#
+spaces_before_comment=2
+
+# Insert a space between the ending comma and closing bracket of a list,
+# etc.
+space_between_ending_comma_and_closing_bracket=True
+
+# Split before arguments
+split_all_comma_separated_values=False
+
+# Split before arguments, but do not split all subexpressions recursively
+# (unless needed).
+split_all_top_level_comma_separated_values=False
+
+# Split before arguments if the argument list is terminated by a
+# comma.
+split_arguments_when_comma_terminated=False
+
+# Set to True to prefer splitting before '+', '-', '*', '/', '//', or '@'
+# rather than after.
+split_before_arithmetic_operator=False
+
+# Set to True to prefer splitting before '&', '|' or '^' rather than
+# after.
+split_before_bitwise_operator=True
+
+# Split before the closing bracket if a list or dict literal doesn't fit on
+# a single line.
+split_before_closing_bracket=True
+
+# Split before a dictionary or set generator (comp_for). For example, note
+# the split before the 'for':
+#
+#   foo = {
+#       variable: 'Hello world, have a nice day!'
+#       for variable in bar if variable != 42
+#   }
+split_before_dict_set_generator=True
+
+# Split before the '.' if we need to split a longer expression:
+#
+#   foo = ('This is a really long string: {}, {}, {}, {}'.format(a, b, c, d))
+#
+# would reformat to something like:
+#
+#   foo = ('This is a really long string: {}, {}, {}, {}'
+#          .format(a, b, c, d))
+split_before_dot=False
+
+# Split after the opening paren which surrounds an expression if it doesn't
+# fit on a single line.
+split_before_expression_after_opening_paren=False
+
+# If an argument / parameter list is going to be split, then split before
+# the first argument.
+split_before_first_argument=False
+
+# Set to True to prefer splitting before 'and' or 'or' rather than
+# after.
+split_before_logical_operator=True
+
+# Split named assignments onto individual lines.
+split_before_named_assigns=True
+
+# Set to True to split list comprehensions and generators that have
+# non-trivial expressions and multiple clauses before each of these
+# clauses. For example:
+#
+#   result = [
+#       a_long_var + 100 for a_long_var in xrange(1000)
+#       if a_long_var % 10]
+#
+# would reformat to something like:
+#
+#   result = [
+#       a_long_var + 100
+#       for a_long_var in xrange(1000)
+#       if a_long_var % 10]
+split_complex_comprehension=False
+
+# The penalty for splitting right after the opening bracket.
+split_penalty_after_opening_bracket=300
+
+# The penalty for splitting the line after a unary operator.
+split_penalty_after_unary_operator=10000
+
+# The penalty of splitting the line around the '+', '-', '*', '/', '//',
+# ``%``, and '@' operators.
+split_penalty_arithmetic_operator=300
+
+# The penalty for splitting right before an if expression.
+split_penalty_before_if_expr=0
+
+# The penalty of splitting the line around the '&', '|', and '^'
+# operators.
+split_penalty_bitwise_operator=300
+
+# The penalty for splitting a list comprehension or generator
+# expression.
+split_penalty_comprehension=80
+
+# The penalty for characters over the column limit.
+split_penalty_excess_character=7000
+
+# The penalty incurred by adding a line split to the unwrapped line. The
+# more line splits added the higher the penalty.
+split_penalty_for_added_line_split=30
+
+# The penalty of splitting a list of "import as" names. For example:
+#
+#   from a_very_long_or_indented_module_name_yada_yad import (long_argument_1,
+#                                                             long_argument_2,
+#                                                             long_argument_3)
+#
+# would reformat to something like:
+#
+#   from a_very_long_or_indented_module_name_yada_yad import (
+#       long_argument_1, long_argument_2, long_argument_3)
+split_penalty_import_names=0
+
+# The penalty of splitting the line around the 'and' and 'or'
+# operators.
+split_penalty_logical_operator=300
+
+# Use the Tab character for indentation.
+use_tabs=False
+
+
+# ================================ Custom rules ===============================
+based_on_style = pep8
+column_limit = 80
+continuation_indent_width = 4
+split_before_logical_operator = true
+blank_line_before_nested_class_or_def = true

--- a/Tools/JsonGenerator/JsonGenerator.py
+++ b/Tools/JsonGenerator/JsonGenerator.py
@@ -1,13 +1,22 @@
 #!/usr/bin/env python
 
-import argparse, sys, re, os, json, posixpath, urllib, glob
+import argparse
+import sys
+import re
+import os
+import json
+import posixpath
+import urllib
+import glob
 from collections import OrderedDict
 
-sys.path.append(os.path.dirname(os.path.abspath(__file__)) + os.sep + "..")
+sys.path.append(os.path.join(os.path.dirname(
+    os.path.abspath(__file__)), os.pardir))
+
 import ProxyStubGenerator.CppParser
 import ProxyStubGenerator.Interface
 
-VERSION="1.4.1"
+VERSION = "1.4.1"
 DEFAULT_DEFINITIONS_FILE = "../ProxyStubGenerator/default.h"
 INTERFACE_NAMESPACE = "::WPEFramework::Exchange"
 
@@ -15,17 +24,23 @@ INTERFACE_NAMESPACE = "::WPEFramework::Exchange"
 class Trace:
     def __init__(self):
         self.errors = 0
+
     def __Print(self, text):
-        print text
+        print(text)
+
     def Header(self, text):
         self.__Print(text)
+
     def Warn(self, text):
-         self.__Print("Warning: " + text)
+        self.__Print("Warning: {}".format(text))
+
     def Error(self, text):
         self.errors += 1
-        self.__Print("Error: " + text)
+        self.__Print("Error: {}".format(text))
+
     def Success(self, text):
-        self.__Print("Success: " + text)
+        self.__Print("Success: {}".format(text))
+
 
 trace = Trace()
 
@@ -33,7 +48,7 @@ try:
     import jsonref
 except:
     trace.Error("Install jsonref first")
-    print "e.g. try 'pip install jsonref'"
+    print("e.g. try 'pip install jsonref'")
     sys.exit(1)
 
 INDENT_SIZE = 4
@@ -63,22 +78,34 @@ IMPL_EVENT_PREFIX = "event_"
 # JSON SCHEMA PARSING
 #
 
+
 class JsonParseError(RuntimeError):
     pass
 
+
 class CppParseError(RuntimeError):
     def __init__(self, obj, msg):
-        msg = "%s(%s): %s (see '%s %s')" % (obj.parser_file, obj.parser_line, msg, " ".join(x if isinstance(x,str) else x.name for x in obj.type), obj.name)
+        msg = "%s(%s): %s (see '%s %s')" % (obj.parser_file, obj.parser_line, msg, " ".join(
+            x if isinstance(x, str) else x.name for x in obj.type), obj.name)
         super(CppParseError, self).__init__(msg)
+
 
 def TypePrefix(type):
     return (TYPE_PREFIX + "::" + type)
+
+
 def MakeObject(type):
     return (type + OBJECT_SUFFIX)
+
+
 def MakeArray(type):
     return (type + ARRAY_SUFFIX)
+
+
 def MakeEnum(type):
     return (type + ENUM_SUFFIX)
+
+
 class JsonType():
     def __init__(self, name, parent, schema, included=None):
         self.name = name
@@ -101,51 +128,72 @@ class JsonType():
                 trace.Warn("Item '%s' name ends with a whitespace" % self.name)
             if self.description and not isinstance(self, JsonMethod):
                 if self.description.endswith("."):
-                    trace.Warn("Item '%s' description ends with a dot (\"%s\")" % (self.name, self.description))
+                    trace.Warn("Item '%s' description ends with a dot (\"%s\")" % (
+                        self.name, self.description))
                 if self.description.endswith(" "):
-                    trace.Warn("Item '%s' description ends with a whitespace" % self.name)
+                    trace.Warn(
+                        "Item '%s' description ends with a whitespace" % self.name)
                 if not self.description[0].isupper() and self.description[0].isalpha():
-                    trace.Warn("Item '%s' description does not start with a capital letter (\"%s\")" % (self.name, self.description))
+                    trace.Warn("Item '%s' description does not start with a capital letter (\"%s\")" % (
+                        self.name, self.description))
         if "default" in schema:
             self.default = schema["default"]
+
     def IsDuplicate(self):      # Whether this object is a duplicate of another
         return self.duplicate
+
     def Schema(self):           # Get the original schema
         return self.schema
+
     def Description(self):      # Item description
         return self.description
+
     def JsonName(self):         # Name as in JSON
         return self.name
+
     def Properties(self):       # Class attributes
         return []
+
     def Objects(self):          # Class aggregate objects
         return []
+
     def CppType(self):          # C++ type of the object (e.g. may be array)
         return self.CppClass()
+
     def CppClass(self):         # C++ class type of the object
         raise RuntimeError("can't instantiate %s" % self.name)
+
     def CppName(self):          # C++ name of the object
         return self.name[0].upper() + self.name[1:]
+
     def CppDefValue(self):      # Value to instantiate with in C++
         return ""
-    def NeedsCopyCtor(self):    # Whether a copy constructor would be needed if this type is a member of a class
+
+    # Whether a copy constructor would be needed if this type is a member of a class
+    def NeedsCopyCtor(self):
         return False
+
     def TrueName(self):
         return self.true_name
+
 
 class JsonNull(JsonType):
     def CppDefValue(self):
         return "nullptr"
+
     def CppType(self):
         return "void"
 
+
 class JsonBoolean(JsonType):
-    #def CppDefValue(self):
+    # def CppDefValue(self):
     #    return "false"
     def CppClass(self):
         return TypePrefix("Boolean")
+
     def CppStdClass(self):
         return "bool"
+
 
 class JsonNumber(JsonType):
     def __init__(self, name, parent, schema):
@@ -157,21 +205,27 @@ class JsonNumber(JsonType):
             self.size = schema["size"]
         if "signed" in schema:
             self.signed = schema["signed"]
-    #def CppDefValue(self):
+    # def CppDefValue(self):
     #    return "0"
+
     def CppClass(self):
         return TypePrefix("Dec%sInt%i" % ("S" if self.signed else "U", self.size))
+
     def CppStdClass(self):
         return "%sint%i_t" % ("" if self.signed else "u", self.size)
 
+
 class JsonInteger(JsonNumber):
-    pass # Identical as Number
+    pass  # Identical as Number
+
 
 class JsonString(JsonType):
     def CppClass(self):
         return TypePrefix("String")
+
     def CppStdClass(self):
         return "string"
+
 
 class JsonEnum(JsonType):
     def __init__(self, name, parent, schema, enumType, included=None):
@@ -183,9 +237,10 @@ class JsonEnum(JsonType):
         self.enumerators = schema["enum"]
         self.values = schema["enumvalues"] if "enumvalues" in schema else []
         if self.values and (len(self.enumerators) != len(self.values)):
-            raise JsonParseError("Mismatch in enumeration values in enum '%s'" % self.JsonName())
+            raise JsonParseError(
+                "Mismatch in enumeration values in enum '%s'" % self.JsonName())
         self.strongly_typed = schema["enumtyped"] if "enumtyped" in schema else True
-        self.default = self.CppClass()+"::"+self.CppEnumerators()[0]
+        self.default = self.CppClass() + "::" + self.CppEnumerators()[0]
         self.duplicate = False
         self.origRef = None
         self.refs = []
@@ -196,8 +251,10 @@ class JsonEnum(JsonType):
             self.origRef = obj
             if obj.parent != parent:
                 obj.AddRef(self)
+
     def CppType(self):
         return TypePrefix("EnumType<%s>" % self.CppClass())
+
     def CppClass(self):
         if self.IsDuplicate():
             # Use the original (ie. first seen) name
@@ -209,32 +266,43 @@ class JsonEnum(JsonType):
                 classname = self.schema["class"].capitalize()
             elif CLASSNAME_FROM_REF and isinstance(self.schema, jsonref.JsonRef):
                 # NOTE: Abuse the ref feature to construct a name for the enum!
-                classname = MakeEnum(self.schema.__reference__["$ref"].rsplit(posixpath.sep,1)[1].capitalize())
+                classname = MakeEnum(self.schema.__reference__[
+                                     "$ref"].rsplit(posixpath.sep, 1)[1].capitalize())
             elif isinstance(self.parent, JsonProperty):
                 classname = MakeEnum(self.parent.name.capitalize())
             else:
                 classname = MakeEnum(self.CppName())
             return classname
+
     def CppEnumerators(self):
-        return map(lambda x: ("E" if x[0].isdigit() else "") + x.upper(), self.enumerators)
+        return list(map(lambda x: ("E" if x[0].isdigit() else "") + x.upper(), self.enumerators))
+
     def CppEnumeratorValues(self):
         return self.values
+
     def IsDuplicate(self):
         return self.duplicate
+
     def OrigName(self):
         return self.JsonName()
+
     def AddRef(self, obj):
         self.refs.append(obj)
+
     def RefCount(self):
         return len(self.refs)
+
     def CppStdClass(self):
         return self.CppClass()
+
     def IsStronglyTyped(self):
         return self.strongly_typed
 
+
 class JsonObject(JsonType):
     def __init__(self, name, parent, schema, origName=None, included=None):
-        self.origName = ((parent.JsonName() + ".") if parent.JsonName() else "") + name
+        self.origName = ((parent.JsonName() + ".")
+                         if parent.JsonName() else "") + name
         JsonType.__init__(self, name, parent, schema, included)
         self.properties = []
         self.objects = []
@@ -251,7 +319,7 @@ class JsonObject(JsonType):
                 self.origRef = obj
                 if obj.parent != parent:
                     obj.AddRef(self)
-            for prop_name, prop in schema["properties"].iteritems():
+            for prop_name, prop in schema["properties"].items():
                 newObject = JsonItem(prop_name, self, prop, included=included)
                 self.properties.append(newObject)
                 # Handle aggregate objects
@@ -270,6 +338,7 @@ class JsonObject(JsonType):
                     self.enums.append(newObject)
         if not self.Properties():
             trace.Warn("No properties in object %s" % self.origName)
+
     def CppName(self):
         # NOTE: Special cases for names for Methods and Arrays
         if isinstance(self.parent, JsonMethod):
@@ -278,6 +347,7 @@ class JsonObject(JsonType):
             return self.parent.CppName()
         else:
             return JsonType.CppName(self)
+
     def CppClass(self):
         if self.IsDuplicate():
             # Use the original (ie. first seen) class name
@@ -292,7 +362,8 @@ class JsonObject(JsonType):
                     return TypePrefix("Container")
                 elif CLASSNAME_FROM_REF and isinstance(self.schema, jsonref.JsonRef):
                     # NOTE: Abuse the ref feature to construct a name for the class!
-                    classname = MakeObject(self.schema.__reference__["$ref"].rsplit(posixpath.sep,1)[1].capitalize())
+                    classname = MakeObject(self.schema.__reference__[
+                                           "$ref"].rsplit(posixpath.sep, 1)[1].capitalize())
                 else:
                     # Make the name out of properties, but not for params/result types
                     if len(self.Properties()) == 1 and not isinstance(self.parent, JsonMethod):
@@ -305,113 +376,155 @@ class JsonObject(JsonType):
                         classname = MakeObject(self.CppName())
             # For common classes append special suffix
             if self.RefCount() > 1:
-                classname = classname.replace(OBJECT_SUFFIX, COMMON_OBJECT_SUFFIX)
+                classname = classname.replace(
+                    OBJECT_SUFFIX, COMMON_OBJECT_SUFFIX)
             return classname
+
     def JsonName(self):
         return self.name.lower()
+
     def Objects(self):
         return self.objects
+
     def Enums(self):
         return self.enums
+
     def Properties(self):
         return self.properties
+
     def NeedsCopyCtor(self):
         # Check if a copy constructory is needed by scanning all duplicate classes
-        return ALWAYS_COPYCTOR or self.parent.NeedsCopyCtor() or filter(lambda obj: obj.parent.NeedsCopyCtor() if self != obj else False, self.refs)
+        filteredClasses = filter(
+            lambda obj: obj.parent.NeedsCopyCtor() if self != obj else False, self.refs)
+        foundInDuplicate = next(filteredClasses, None)
+        return ALWAYS_COPYCTOR or self.parent.NeedsCopyCtor() or foundInDuplicate is not None
+
     def AddRef(self, obj):
         self.refs.append(obj)
+
     def RefCount(self):
         return len(self.refs)
+
     def IsDuplicate(self):
         return self.duplicate
+
     def OrigName(self):
         return self.origName
+
     def CppStdClass(self):
         return TypePrefix("Container")
+
 
 class JsonArray(JsonType):
     def __init__(self, name, parent, schema, origName=None, included=None):
         JsonType.__init__(self, name, parent, schema, included)
         self.items = None
         if "items" in schema:
-            self.items = JsonItem(name, self, schema["items"], origName, included)
+            self.items = JsonItem(
+                name, self, schema["items"], origName, included)
         else:
             raise JsonParseError("no items in array '%s'" % name)
+
     def CppName(self):
         # Take the name of the array from the method if this array is result type
         if isinstance(self.parent, JsonMethod):
             return self.parent.CppName() + JsonType.CppName(self)
         else:
             return JsonType.CppName(self)
+
     def CppType(self):
         return TypePrefix("ArrayType<%s>" % self.items.CppType())
+
     def NeedsCopyCtor(self):
         # Important, blame it on the arrays!
         return True
+
     def Items(self):
         return self.items
     # Delegate all other methods to the underlying type
+
     def CppClass(self):
         return self.Items().CppClass()
+
     def Enums(self):
         return self.Items().Enums()
+
     def Objects(self):
         return self.Items().Objects()
+
     def Properties(self):
         return self.Items().Properties()
+
     def IsDuplicate(self):
         return self.Items().IsDuplicate()
+
     def RefCount(self):
         return self.Items().RefCount()
+
     def CppStdClass(self):
         return "/* TODO */"
 
+
 class JsonMethod(JsonObject):
-    def __init__(self, name, parent, schema, included = None):
+    def __init__(self, name, parent, schema, included=None):
         objName = name.rsplit(".", 1)[1] if "." in name else name
         # Mimic a JSON object to fit rest of the parsing...
         self.errors = schema["errors"] if "errors" in schema else OrderedDict()
-        newschema = { "type": "object" }
+        newschema = {"type": "object"}
         props = OrderedDict()
-        props["params"] = schema["params"] if "params" in schema else { "type": "null" }
-        props["result"] = schema["result"] if "result" in schema else { "type": "null" }
+        props["params"] = schema["params"] if "params" in schema else {
+            "type": "null"}
+        props["result"] = schema["result"] if "result" in schema else {
+            "type": "null"}
         newschema["properties"] = props
-        JsonObject.__init__(self, objName, parent, newschema, included=included)
+        JsonObject.__init__(self, objName, parent,
+                            newschema, included=included)
         self.summary = None
         self.tags = []
         if "summary" in schema:
             self.summary = schema["summary"]
         if "tags" in schema:
             self.tags = schema["tags"]
+
     def Errors(self):
         return self.errors
+
     def MethodName(self):
         return IMPL_ENDPOINT_PREFIX + JsonObject.JsonName(self)
+
     def Summary(self):
         return self.summary
 
+
 class JsonNotification(JsonMethod):
-    def __init__(self, name, parent, schema, included = None):
+    def __init__(self, name, parent, schema, included=None):
         JsonMethod.__init__(self, name, parent, schema, included)
         self.sendif = "id" in schema
         self.statuslistener = schema["statuslistener"] if "statuslistener" in schema else False
+
     def HasSendif(self):
         return self.sendif
+
     def StatusListener(self):
         return self.statuslistener
+
     def MethodName(self):
         return IMPL_EVENT_PREFIX + JsonObject.JsonName(self)
 
+
 class JsonProperty(JsonMethod):
-    def __init__(self, name, parent, schema, included = None):
+    def __init__(self, name, parent, schema, included=None):
         JsonMethod.__init__(self, name, parent, schema, included)
         self.readonly = "readonly" in schema and schema["readonly"] == True
         self.writeonly = "writeonly" in schema and schema["writeonly"] == True
-        self.has_index ="index" in schema
+        self.has_index = "index" in schema
+
     def SetMethodName(self):
         return "set_" + JsonObject.JsonName(self)
+
     def GetMethodName(self):
         return "get_" + JsonObject.JsonName(self)
+
 
 class JsonRpcSchema(JsonType):
     def __init__(self, name, schema):
@@ -430,27 +543,28 @@ class JsonRpcSchema(JsonType):
         if "interface" in schema:
             schema = schema["interface"]
         if "include" in schema:
-            for name, s in schema["include"].iteritems():
+            for name, s in schema["include"].items():
                 include = s["info"]["class"]
                 self.includes.append(include)
                 if "methods" in s:
-                    for name, method in s["methods"].iteritems():
+                    for name, method in s["methods"].items():
                         newMethod = JsonMethod(name, self, method, include)
                         self.methods.append(newMethod)
                 if "properties" in s:
-                    for name, method in s["properties"].iteritems():
+                    for name, method in s["properties"].items():
                         newMethod = JsonProperty(name, self, method, include)
                         self.methods.append(newMethod)
                 if "events" in s:
-                    for name, method in s["events"].iteritems():
-                        newMethod = JsonNotification(name, self, method, include)
+                    for name, method in s["events"].items():
+                        newMethod = JsonNotification(
+                            name, self, method, include)
                         self.methods.append(newMethod)
 
-        method_list = map(lambda x: x.name, self.methods)
+        method_list = list(map(lambda x: x.name, self.methods))
 
         def __AddMethods(section, schema, ctor):
             if section in schema:
-                for name, method in schema[section].iteritems():
+                for name, method in schema[section].items():
                     if name in method_list:
                         del self.methods[method_list.index(name)]
                         method_list.remove(name)
@@ -458,23 +572,32 @@ class JsonRpcSchema(JsonType):
                         newMethod = ctor(name, self, method)
                         self.methods.append(newMethod)
 
-        __AddMethods("methods", schema, lambda name, obj,  method: JsonMethod(name, obj, method))
-        __AddMethods("properties", schema, lambda name, obj, method: JsonProperty(name, obj, method))
-        __AddMethods("events", schema, lambda name, obj, method: JsonNotification(name, obj, method))
+        __AddMethods("methods", schema, lambda name, obj,
+                     method: JsonMethod(name, obj, method))
+        __AddMethods("properties", schema, lambda name, obj,
+                     method: JsonProperty(name, obj, method))
+        __AddMethods("events", schema, lambda name, obj,
+                     method: JsonNotification(name, obj, method))
 
         if not self.methods:
-            raise JsonParseError("no methods, properties or events defined in '%s'" % name)
+            raise JsonParseError(
+                "no methods, properties or events defined in '%s'" % name)
 
     def CppClass(self):
         return JsonType.CppName(self)
+
     def Properties(self):
         return self.methods
+
     def Objects(self):
         return self.Properties()
+
     def NeedsCopyCtor(self):
         return False
+
     def RefCount(self):
         return 1
+
 
 def JsonItem(name, parent, schema, origName=None, included=None):
     # Create the appropriate Python object based on the JSON type
@@ -500,20 +623,28 @@ def JsonItem(name, parent, schema, origName=None, included=None):
     else:
         raise JsonParseError("undefined type for item: %s" % name)
 
+
 def LoadSchema(file, include_path, cpp_include_path):
-    def PreprocessJson(file, string, include_path = None, cpp_include_path = None):
+    def PreprocessJson(file, string, include_path=None, cpp_include_path=None):
         def __Tokenize(contents):
             # Tokenize the JSON first to be able to preprocess it easier
-            formula = ( \
-                    r"(/\*(.|[\r\n])*?\*/)"                                                 # multi-line comments
-                    r"|(//.*)"                                                              # single line comments
-                    r'|("(?:[^\\"]|\\.)*")'                                                 # double quotes
-                    r"|('(?:[^\\']|\\.)*')"                                                 # singe quotes
-                    r"|([~,:;?=^/*-\+&<>\{\}\(\)\[\]])"                                     # single-char operators
-                    )
-            tokens = [s.strip() for s in re.split(formula, contents, flags=re.MULTILINE) if s]
+            formula = (
+                # multi-line comments
+                r"(/\*(.|[\r\n])*?\*/)"
+                # single line comments
+                r"|(//.*)"
+                # double quotes
+                r'|("(?:[^\\"]|\\.)*")'
+                # singe quotes
+                r"|('(?:[^\\']|\\.)*')"
+                # single-char operators
+                r"|([~,:;?=^/*-\+&<>\{\}\(\)\[\]])"
+            )
+            tokens = [s.strip() for s in re.split(
+                formula, contents, flags=re.MULTILINE) if s]
             # Remove comments from the JSON
-            tokens = [s for s in tokens if (s and (s[:2] != '/*' and s[:2] != '//'))]
+            tokens = [s for s in tokens if (
+                s and (s[:2] != '/*' and s[:2] != '//'))]
             return tokens
         path = os.path.abspath(os.path.dirname(file))
         tokens = __Tokenize(string)
@@ -521,9 +652,11 @@ def LoadSchema(file, include_path, cpp_include_path):
         for c, t in enumerate(tokens):
             if t == '"$ref"' and tokens[c + 1] == ":" and tokens[c + 2][:2] != '"#':
                 ref_file = tokens[c + 2].strip('"')
-                ref_tok = ref_file.split("#", 1) if "#" in ref_file else [ref_file, ""]
+                ref_tok = ref_file.split("#", 1) if "#" in ref_file else [
+                    ref_file, ""]
                 if "{interfacedir}/" in ref_file:
-                    ref_tok[0] = ref_tok[0].replace("{interfacedir}/", (include_path + os.sep) if include_path else "")
+                    ref_tok[0] = ref_tok[0].replace(
+                        "{interfacedir}/", (include_path + os.sep) if include_path else "")
                     if not include_path:
                         ref_tok[0] = os.path.join(path, ref_tok[0])
                 else:
@@ -531,36 +664,45 @@ def LoadSchema(file, include_path, cpp_include_path):
                         ref_tok[0] = os.path.join(path, ref_tok[0])
                 if not os.path.isfile(ref_tok[0]):
                     raise RuntimeError("$ref file '%s' not found" % ref_tok[0])
-                ref_file = '"file:%s#%s"' % (urllib.pathname2url(ref_tok[0]), ref_tok[1])
+                ref_file = '"file:%s#%s"' % (
+                    urllib.request.pathname2url(ref_tok[0]), ref_tok[1])
                 tokens[c + 2] = ref_file
             elif t == '"$cppref"' and tokens[c + 1] == ":" and tokens[c + 2][:2] != '"#':
                 ref_file = tokens[c + 2].strip('"')
-                ref_tok = ref_file.split("#", 1) if "#" in ref_file else [ref_file, ""]
+                ref_tok = ref_file.split("#", 1) if "#" in ref_file else [
+                    ref_file, ""]
                 if "{cppinterfacedir}/" in ref_file:
-                    ref_tok[0] = ref_tok[0].replace("{cppinterfacedir}/", (cpp_include_path + os.sep) if cpp_include_path else "")
+                    ref_tok[0] = ref_tok[0].replace(
+                        "{cppinterfacedir}/", (cpp_include_path + os.sep) if cpp_include_path else "")
                     if not cpp_include_path:
                         ref_tok[0] = os.path.join(path, ref_tok[0])
                 else:
                     if os.path.isfile(os.path.join(path, ref_tok[0])):
                         ref_tok[0] = os.path.join(path, ref_tok[0])
                 if not os.path.isfile(ref_tok[0]):
-                    raise RuntimeError("$cppref file '%s' not found" % ref_tok[0])
-                cppif =  LoadInterface(ref_tok[0])
+                    raise RuntimeError(
+                        "$cppref file '%s' not found" % ref_tok[0])
+                cppif = LoadInterface(ref_tok[0])
                 if cppif:
                     tokens[c] = json.dumps(cppif[0])[1:-1]
-                    tokens[c+1] = ""
-                    tokens[c+2] = ""
+                    tokens[c + 1] = ""
+                    tokens[c + 2] = ""
                 else:
-                    raise RuntimeError("failed to parse C++ header '%s'" % ref_tok[0])
+                    raise RuntimeError(
+                        "failed to parse C++ header '%s'" % ref_tok[0])
         # Return back the preprocessed JSON as a string
         return " ".join(tokens)
     with open(file, "r") as json_file:
-        jsonPre = PreprocessJson(file, json_file.read(), include_path, cpp_include_path)
+        jsonPre = PreprocessJson(
+            file, json_file.read(), include_path, cpp_include_path)
         return jsonref.loads(jsonPre, object_pairs_hook=OrderedDict)
 
+
 def LoadInterface(file):
-    tree = ProxyStubGenerator.CppParser.ParseFiles([os.path.join(os.path.dirname(os.path.realpath(__file__)), posixpath.normpath(DEFAULT_DEFINITIONS_FILE)), file])
-    interfaces = [i for i in ProxyStubGenerator.Interface.FindInterfaceClasses(tree, INTERFACE_NAMESPACE, file) if i.obj.is_json]
+    tree = ProxyStubGenerator.CppParser.ParseFiles([os.path.join(os.path.dirname(
+        os.path.realpath(__file__)), posixpath.normpath(DEFAULT_DEFINITIONS_FILE)), file])
+    interfaces = [i for i in ProxyStubGenerator.Interface.FindInterfaceClasses(
+        tree, INTERFACE_NAMESPACE, file) if i.obj.is_json]
 
     def Build(face):
         schema = OrderedDict()
@@ -578,7 +720,7 @@ def LoadInterface(file):
         info["description"] = info["class"] + " JSON-RPC interface"
         schema["info"] = info
 
-        commons  = dict()
+        commons = dict()
         commons["$ref"] = "common.json"
         schema["common"] = commons
 
@@ -605,21 +747,26 @@ def LoadInterface(file):
                     return "number", 64, None
                 elif "long double" in cppType:
                     return "number", 128, None
-                elif cppType == [ "void" ]:
+                elif cppType == ["void"]:
                     return "null", None, None
                 else:
-                    raise CppParseError(var, "unable to convert C++ type to JSON type")
+                    raise CppParseError(
+                        var, "unable to convert C++ type to JSON type")
 
             def ConvertParameter(var):
                 jsonType, size, signed = ConvertType(var)
-                properties = { "type": jsonType }
-                if size: properties["size"] = size
-                if signed: properties["signed"] = signed
+                properties = {"type": jsonType}
+                if size:
+                    properties["size"] = size
+                if signed:
+                    properties["signed"] = signed
                 if var.brief:
-                    egidx = var.brief.index("(e.g.") if "(e.g" in var.brief else None
+                    egidx = var.brief.index(
+                        "(e.g.") if "(e.g" in var.brief else None
                     properties["description"] = var.brief[0:egidx].strip()
-                    if egidx and ")" in var.brief[egidx+1:]:
-                        properties["example"] = var.brief[egidx+5:var.brief.index(")")].strip()
+                    if egidx and ")" in var.brief[egidx + 1:]:
+                        properties["example"] = var.brief[egidx +
+                                                          5:var.brief.index(")")].strip()
                 return properties
 
             def EventParameters(vars):
@@ -640,14 +787,15 @@ def LoadInterface(file):
                     events = ResolveTypedef(resolved, events, var.type)
                 return events
 
-            def BuildParameters(vars, prop = False):
-                params = { "type": "object" }
+            def BuildParameters(vars, prop=False):
+                params = {"type": "object"}
                 properties = OrderedDict()
                 required = []
                 for var in vars:
                     if var.input or not var.output:
                         if (var.type[-1] == "&" or var.type[-1] == "*") and var.type[0] != "const" and not var.input:
-                            raise CppParseError(var, "non-const pointer/reference parameter requires in/out tag")
+                            raise CppParseError(
+                                var, "non-const pointer/reference parameter requires in/out tag")
                         var_name = var.name.lower()
                         properties[var_name] = ConvertParameter(var)
                         required.append(var_name)
@@ -655,7 +803,7 @@ def LoadInterface(file):
                 params["required"] = required
                 if prop:
                     if len(properties) == 1:
-                        return properties.values()[0]
+                        return list(properties.values())[0]
                     elif len(properties) > 1:
                         params["required"] = required
                         return params
@@ -667,19 +815,20 @@ def LoadInterface(file):
                     return params
 
             def BuildResult(vars):
-                params = { "type": "object" }
+                params = {"type": "object"}
                 properties = OrderedDict()
                 required = []
                 for var in vars:
                     if var.output:
                         if var.type[-1] != "&" and var.type[-1] != "&":
-                            raise CppParseError(var, "parameter marked with @out tag must be either reference or pointer")
+                            raise CppParseError(
+                                var, "parameter marked with @out tag must be either reference or pointer")
                         var_name = var.name.lower()
                         properties[var_name] = ConvertParameter(var)
                         required.append(var_name)
                 params["properties"] = properties
                 if len(properties) == 1:
-                    return properties.values()[0]
+                    return list(properties.values())[0]
                 elif len(properties) > 1:
                     params["required"] = required
                     return params
@@ -697,7 +846,8 @@ def LoadInterface(file):
                         return ResolveTypedef(type.type[0])
                     else:
                         return type
-                event_interfaces.add(ProxyStubGenerator.Interface.Interface(ResolveTypedef(e), 0, file))
+                event_interfaces.add(ProxyStubGenerator.Interface.Interface(
+                    ResolveTypedef(e), 0, file))
 
             obj = None
 
@@ -710,7 +860,8 @@ def LoadInterface(file):
                 if len(method.vars) == 1:
                     if "const" in method.qualifiers:
                         if "const" in method.vars[0].type:
-                            raise CppParseError(method.vars[0], "property getter method must not use const parameter")
+                            raise CppParseError(
+                                method.vars[0], "property getter method must not use const parameter")
                         else:
                             if "writeonly" in obj:
                                 del obj["writeonly"]
@@ -720,16 +871,19 @@ def LoadInterface(file):
                                 obj["params"] = BuildResult([method.vars[0]])
                     else:
                         if "const" not in method.vars[0].type:
-                            raise CppParseError(method.vars[0], "property setter method must use a const parameter")
+                            raise CppParseError(
+                                method.vars[0], "property setter method must use a const parameter")
                         else:
                             if "readonly" in obj:
                                 del obj["readonly"]
                             else:
                                 obj["writeonly"] = True
                             if "params" not in obj:
-                                obj["params"] = BuildParameters([method.vars[0]], True)
+                                obj["params"] = BuildParameters(
+                                    [method.vars[0]], True)
                 else:
-                    raise CppParseError(method, "property method must have one parameter")
+                    raise CppParseError(
+                        method, "property method must have one parameter")
 
             elif "pure-virtual" in method.specifiers and not event_params:
                 obj = OrderedDict()
@@ -771,9 +925,9 @@ def LoadInterface(file):
             schema["events"] = events
 
         if DUMP_JSON:
-            print "\n// JSON interface for %s -----------" % face.obj.name
-            print json.dumps(schema, indent=2)
-            print "// ----------------\n"
+            print("\n// JSON interface for {} -----------".format(face.obj.name))
+            print(json.dumps(schema, indent=2))
+            print("// ----------------\n")
         return schema
 
     schemas = []
@@ -801,21 +955,26 @@ def ParseJsonRpcSchema(schema):
     else:
         return None
 
+
 def SortByDependency(objects):
     sortedObjects = []
     # This will order objects by their relations
     for obj in sorted(objects, key=lambda x: x.CppClass(), reverse=False):
-        found = filter(lambda sortedObj: obj.CppClass() in map(lambda x: x.CppClass(), sortedObj.Objects()), sortedObjects)
-        if found:
+        found = filter(lambda sortedObj: obj.CppClass() in map(
+            lambda x: x.CppClass(), sortedObj.Objects()), sortedObjects)
+        try:
             index = min(map(lambda x: sortedObjects.index(x), found))
-            movelist = filter(lambda x: x.CppClass() in map(lambda x: x.CppClass(), sortedObjects), obj.Objects())
+            movelist = filter(lambda x: x.CppClass() in map(
+                lambda x: x.CppClass(), sortedObjects), obj.Objects())
             sortedObjects.insert(index, obj)
             for m in movelist:
                 if m in sortedObjects:
-                    sortedObjects.insert(index, sortedObjects.pop(sortedObjects.index(m)))
-        else:
+                    sortedObjects.insert(
+                        index, sortedObjects.pop(sortedObjects.index(m)))
+        except ValueError:
             sortedObjects.append(obj)
     return sortedObjects
+
 
 def IsInRef(obj):
     while obj:
@@ -824,14 +983,16 @@ def IsInRef(obj):
         obj = obj.parent
     return False
 
+
 class ObjectTracker:
     def __init__(self):
         self.objects = []
         self.Reset()
+
     def Add(self, newObj):
         def __Compare(lhs, rhs):
             # NOTE: Two objects are considered identical if they have the same property names and types only!
-            for name, prop in lhs.iteritems():
+            for name, prop in lhs.items():
                 if name not in rhs:
                     return False
                 elif rhs[name]["type"] != prop["type"]:
@@ -842,7 +1003,7 @@ class ObjectTracker:
                             return False
                     else:
                         return False
-            for name, prop in rhs.iteritems():
+            for name, prop in rhs.items():
                 if name not in lhs:
                     return False
                 elif lhs[name]["type"] != prop["type"]:
@@ -861,21 +1022,27 @@ class ObjectTracker:
             for obj in self.Objects()[:-1]:
                 if __Compare(obj.Schema()["properties"], props):
                     if not is_ref or not IsInRef(obj):
-                        trace.Warn("Duplicate object '%s' (same as '%s') - consider using $ref" % (newObj.OrigName(), obj.OrigName()))
+                        trace.Warn("Duplicate object '%s' (same as '%s') - consider using $ref" %
+                                   (newObj.OrigName(), obj.OrigName()))
                     return obj
             return None
+
     def Objects(self):
         return self.objects
+
     def Reset(self):
         self.objects = []
+
     def CommonObjects(self):
         return SortByDependency(filter(lambda obj: obj.RefCount() > 1, self.Objects()))
+
 
 class EnumTracker(ObjectTracker):
     def __IsTopmost(self, obj):
         while isinstance(obj.parent, JsonArray):
             obj = obj.parent
         return isinstance(obj.parent, JsonMethod)
+
     def Add(self, newObj):
         def __Compare(lhs, rhs):
             # NOTE: Two enums are considered identical if they have the same enumeration names and types
@@ -896,9 +1063,11 @@ class EnumTracker(ObjectTracker):
             for obj in self.Objects()[:-1]:
                 if __Compare(obj.Schema(), newObj.Schema()):
                     if not is_ref or not IsInRef(obj):
-                        trace.Warn("Duplicate enums '%s' (same as '%s') - consider using $ref" % (newObj.OrigName(), obj.OrigName()))
+                        trace.Warn("Duplicate enums '%s' (same as '%s') - consider using $ref" %
+                                   (newObj.OrigName(), obj.OrigName()))
                     return obj
             return None
+
     def CommonObjects(self):
         return SortByDependency(filter(lambda obj: obj.RefCount() > 1 or self.__IsTopmost(obj), self.Objects()))
 
@@ -906,18 +1075,22 @@ class EnumTracker(ObjectTracker):
 # THE EMITTER
 #
 
+
 class Emitter():
     def __init__(self, file, indentSize):
         self.indent_size = indentSize
         self.indent = 0
         self.file = file
-    def Line(self, text = ""):
+
+    def Line(self, text=""):
         if text != "":
             self.file.write(" " * self.indent + str(text) + "\n")
         else:
             self.file.write("\n")
+
     def Indent(self):
         self.indent += self.indent_size
+
     def Unindent(self):
         if self.indent >= self.indent_size:
             self.indent -= self.indent_size
@@ -928,7 +1101,8 @@ class Emitter():
 # JSON OBJECT GENERATION
 #
 
-def GetNamespace(root, obj, full = True):
+
+def GetNamespace(root, obj, full=True):
     namespace = ""
     if isinstance(obj, (JsonObject, JsonEnum, JsonArray)):
         if isinstance(obj, JsonObject) and not obj.properties:
@@ -937,7 +1111,7 @@ def GetNamespace(root, obj, full = True):
         e = obj
         while e.parent and not isinstance(e, JsonMethod) and (not e.IsDuplicate() or e.RefCount() > 1):
             if not isinstance(e, (JsonEnum, JsonArray)):
-                fullname = e.CppClass()+ "::" + fullname
+                fullname = e.CppClass() + "::" + fullname
             if e.RefCount() > 1:
                 break
             e = e.parent
@@ -948,12 +1122,14 @@ def GetNamespace(root, obj, full = True):
 
 
 def EmitEnumRegs(root, emit, header_file):
-    def EmitEnumRegistration(root, enum, full = True):
-        fullname = (GetNamespace(root, enum) if full else "%s::%s::" % (DATA_NAMESPACE, root.CppClass())) + enum.CppClass()
+    def EmitEnumRegistration(root, enum, full=True):
+        fullname = (GetNamespace(root, enum) if full else "%s::%s::" %
+                    (DATA_NAMESPACE, root.CppClass())) + enum.CppClass()
         emit.Line("ENUM_CONVERSION_BEGIN(%s)" % fullname)
         emit.Indent()
         for c, item in enumerate(enum.enumerators):
-            emit.Line("{ %s::%s, _TXT(\"%s\") }," % (fullname, enum.CppEnumerators()[c], item))
+            emit.Line("{ %s::%s, _TXT(\"%s\") }," %
+                      (fullname, enum.CppEnumerators()[c], item))
         emit.Unindent()
         emit.Line("ENUM_CONVERSION_END(%s);" % fullname)
 
@@ -977,18 +1153,22 @@ def EmitEnumRegs(root, emit, header_file):
     emit.Line("}")
     return count
 
-def EmitEvent(emit, root, event, static = False):
+
+def EmitEvent(emit, root, event, static=False):
     if event.Summary():
-        emit.Line("// Event: %s - %s" % (event.JsonName(), event.Summary().split(".",1)[0]))
+        emit.Line("// Event: %s - %s" %
+                  (event.JsonName(), event.Summary().split(".", 1)[0]))
     else:
         emit.Line("// Event: %s" % event.JsonName())
     params = event.Properties()[0].CppType()
     par = "const string& id, " if event.HasSendif() else ""
-    par = par + ", ".join(map(lambda x: "const " + GetNamespace(root, x, False) + x.CppStdClass() + "& " + x.JsonName(), event.Properties()[0].Properties()))
+    par = par + ", ".join(map(lambda x: "const " + GetNamespace(root, x, False) +
+                              x.CppStdClass() + "& " + x.JsonName(), event.Properties()[0].Properties()))
     if not static:
         line = "void %s::%s(%s)" % (root.JsonName(), event.MethodName(), par)
     else:
-        line = "static void %s(PluginHost::JSONRPC& module%s%s)" % (event.TrueName(), ", " if par else "", par)
+        line = "static void %s(PluginHost::JSONRPC& module%s%s)" % (
+            event.TrueName(), ", " if par else "", par)
     if event.included_from:
         line += " /* %s */" % event.included_from
     emit.Line(line)
@@ -1000,14 +1180,17 @@ def EmitEvent(emit, root, event, static = False):
             emit.Line("params.%s = %s;" % (p.CppName(), p.JsonName()))
         emit.Line()
     if event.HasSendif():
-        emit.Line('Notify(_T("%s")%s, [&](const string& designator) -> bool {' % (event.JsonName(), ", params" if params != "void" else ""))
+        emit.Line('Notify(_T("%s")%s, [&](const string& designator) -> bool {' % (
+            event.JsonName(), ", params" if params != "void" else ""))
         emit.Indent()
-        emit.Line("const string designator_id = designator.substr(0, designator.find('.'));")
+        emit.Line(
+            "const string designator_id = designator.substr(0, designator.find('.'));")
         emit.Line("return (id == designator_id);")
         emit.Unindent()
         emit.Line("});")
     else:
-        emit.Line('%sNotify(_T("%s")%s);' % ("module." if static else "", event.JsonName(), ", params" if params != "void" else ""))
+        emit.Line('%sNotify(_T("%s")%s);' % ("module." if static else "",
+                                             event.JsonName(), ", params" if params != "void" else ""))
     emit.Unindent()
     emit.Line("}")
     emit.Line()
@@ -1034,7 +1217,8 @@ def EmitRpcCode(root, emit, header_file, source_file):
     emit.Line("struct %s {" % struct)
     emit.Indent()
     emit.Line()
-    emit.Line("static void Register(PluginHost::JSONRPC& module, %s* destination)" % face)
+    emit.Line(
+        "static void Register(PluginHost::JSONRPC& module, %s* destination)" % face)
     emit.Line("{")
     emit.Indent()
     emit.Line("ASSERT(destination != nullptr);")
@@ -1049,34 +1233,41 @@ def EmitRpcCode(root, emit, header_file, source_file):
                 params = m.Properties()[0] if not m.readonly else void
                 response = m.Properties()[0] if not m.writeonly else void
                 response.name = "result"
-                emit.Line("// Property: '%s'%s%s%s" % (m.JsonName(), " (r/o)" if m.readonly else (" (w/o)" if m.writeonly else ""), " - " if m.summary else "", m.summary if m.summary else ""))
+                emit.Line("// Property: '%s'%s%s%s" % (m.JsonName(), " (r/o)" if m.readonly else (
+                    " (w/o)" if m.writeonly else ""), " - " if m.summary else "", m.summary if m.summary else ""))
             else:
                 params = m.Properties()[0]
                 response = m.Properties()[1]
-                emit.Line("// Method: '%s'%s%s" % (m.JsonName(), " - " if m.summary else "", m.summary if m.summary else ""))
-            line = 'module.Register<%s,%s>(_T("%s"),' % (params.CppType(), response.CppType(), m.JsonName())
+                emit.Line("// Method: '%s'%s%s" % (m.JsonName(),
+                                                   " - " if m.summary else "", m.summary if m.summary else ""))
+            line = 'module.Register<%s,%s>(_T("%s"),' % (
+                params.CppType(), response.CppType(), m.JsonName())
             emit.Line(line)
             emit.Indent()
             line = '[destination]('
             line = line + (("const " + params.CppType() + "& params") if params.CppType() != "void" else "") + \
-                           (", " if params.CppType() != "void" and response.CppType() != "void" else "") + \
-                          ((response.CppType() + "& response") if response.CppType() != "void" else "")
+                (", " if params.CppType() != "void" and response.CppType() != "void" else "") + \
+                ((response.CppType() + "& response")
+                 if response.CppType() != "void" else "")
             line = line + ') -> uint32_t {'
             emit.Line(line)
             emit.Indent()
             emit.Line("uint32_t errorCode;")
 
-            def Invoke(params, response, const_cast = False):
+            def Invoke(params, response, const_cast=False):
                 if response.CppType() != "void":
                     if isinstance(response, JsonObject):
                         for p in response.Properties():
                             if not isinstance(p, (JsonObject, JsonArray)):
-                                emit.Line("%s %s{};" % (p.CppStdClass(), p.JsonName()))
+                                emit.Line("%s %s{};" %
+                                          (p.CppStdClass(), p.JsonName()))
                     else:
-                        emit.Line("%s %s{};" % (response.CppStdClass(), response.JsonName()))
+                        emit.Line("%s %s{};" %
+                                  (response.CppStdClass(), response.JsonName()))
 
                 if const_cast:
-                    line = "errorCode = (const_cast<const %s*>(destination))->%s(" % (face, m.TrueName())
+                    line = "errorCode = (const_cast<const %s*>(destination))->%s(" % (
+                        face, m.TrueName())
                 else:
                     line = "errorCode = destination->%s(" % m.TrueName()
                 if params.CppType() != "void":
@@ -1105,9 +1296,11 @@ def EmitRpcCode(root, emit, header_file, source_file):
                     if isinstance(response, JsonObject):
                         for p in response.Properties():
                             if not isinstance(p, (JsonObject, JsonArray)):
-                                emit.Line("response.%s = %s;" % (p.CppName(), p.JsonName()))
+                                emit.Line("response.%s = %s;" %
+                                          (p.CppName(), p.JsonName()))
                     else:
-                        emit.Line("%s = %s;" % ("response", response.JsonName()))
+                        emit.Line("%s = %s;" %
+                                  ("response", response.JsonName()))
                     emit.Unindent()
                     emit.Line("}")
 
@@ -1181,20 +1374,22 @@ def EmitRpcCode(root, emit, header_file, source_file):
     emit.Line("}")
     emit.Line()
 
+
 def EmitHelperCode(root, emit, header_file):
     if root.Objects():
         namespace = DATA_NAMESPACE + "::" + root.JsonName()
 
         def __NsName(obj):
-            ns = DATA_NAMESPACE + "::" + (root.JsonName() if not obj.included_from else obj.included_from)
+            ns = DATA_NAMESPACE + "::" + \
+                (root.JsonName() if not obj.included_from else obj.included_from)
             objName = obj.CppType()
             if objName != "void":
                 if not objName.startswith(TYPE_PREFIX):
                     objName = ns + "::" + objName
                 p = objName.find("<", 0)
                 while p != -1:
-                    if not objName.startswith(TYPE_PREFIX, p+1):
-                        objName = objName[:p+1] + ns + "::" + objName[p+1:]
+                    if not objName.startswith(TYPE_PREFIX, p + 1):
+                        objName = objName[:p + 1] + ns + "::" + objName[p + 1:]
                     p = objName.find("<", p + 1)
             return objName
 
@@ -1212,11 +1407,13 @@ def EmitHelperCode(root, emit, header_file):
                 has_statuslistener = True
                 break
 
-        print "Emitting registration code..."
+        print("Emitting registration code...")
         emit.Line("/*")
         emit.Indent()
-        emit.Line("// Copy the code below to %s class definition" % root.JsonName())
-        emit.Line("// Note: The %s class must inherit from PluginHost::JSONRPC%s" % (root.JsonName(), "SupportsEventStatus" if has_statuslistener else ""))
+        emit.Line("// Copy the code below to %s class definition" %
+                  root.JsonName())
+        emit.Line("// Note: The %s class must inherit from PluginHost::JSONRPC%s" %
+                  (root.JsonName(), "SupportsEventStatus" if has_statuslistener else ""))
         emit.Line()
         emit.Line("private:")
         emit.Indent()
@@ -1225,11 +1422,12 @@ def EmitHelperCode(root, emit, header_file):
         for method in root.Properties():
             if not isinstance(method, JsonProperty) and not isinstance(method, JsonNotification):
                 params = __NsName(method.Properties()[0])
-                response  = __NsName(method.Properties()[1])
-                line = ("uint32_t %s(%s%s%s);" % (method.MethodName(), \
-                                ("const " + params + "& params") if params != "void" else "", \
-                                ", " if params != "void" and response != "void" else "", \
-                                (response + "& response") if response != "void" else ""))
+                response = __NsName(method.Properties()[1])
+                line = ("uint32_t %s(%s%s%s);" % (method.MethodName(),
+                                                  ("const " + params +
+                                                   "& params") if params != "void" else "",
+                                                  ", " if params != "void" and response != "void" else "",
+                                                  (response + "& response") if response != "void" else ""))
                 if method.included_from:
                     line += " // %s" % method.included_from
                 emit.Line(line)
@@ -1237,12 +1435,14 @@ def EmitHelperCode(root, emit, header_file):
         for method in root.Properties():
             if isinstance(method, JsonProperty):
                 if not method.writeonly:
-                    line = "uint32_t %s(%s%s& response) const;" % (method.GetMethodName(), "const string& index, " if method.has_index else "", __NsName(method.Properties()[0]))
+                    line = "uint32_t %s(%s%s& response) const;" % (method.GetMethodName(
+                    ), "const string& index, " if method.has_index else "", __NsName(method.Properties()[0]))
                     if method.included_from:
                         line += " // %s" % method.included_from
                     emit.Line(line)
                 if not method.readonly:
-                    line = "uint32_t %s(%sconst %s& param);" % (method.SetMethodName(), "const string& index, " if method.has_index else "", __NsName(method.Properties()[0]))
+                    line = "uint32_t %s(%sconst %s& param);" % (method.SetMethodName(
+                    ), "const string& index, " if method.has_index else "", __NsName(method.Properties()[0]))
                     if method.included_from:
                         line += " // %s" % method.included_from
                     emit.Line(line)
@@ -1252,8 +1452,10 @@ def EmitHelperCode(root, emit, header_file):
                 params = __NsName(method.Properties()[0])
                 par = ""
                 if params != "void":
-                    par = ", ".join(map(lambda x: "const " + GetNamespace(root, x) + x.CppStdClass() + "& " + x.JsonName(), method.Properties()[0].Properties()))
-                line = ('void %s(%s%s);' % (method.MethodName(), "const string& id, " if method.HasSendif() else "", par))
+                    par = ", ".join(map(lambda x: "const " + GetNamespace(root, x) + x.CppStdClass(
+                    ) + "& " + x.JsonName(), method.Properties()[0].Properties()))
+                line = ('void %s(%s%s);' % (method.MethodName(),
+                                            "const string& id, " if method.HasSendif() else "", par))
                 if method.included_from:
                     line += " // %s" % method.included_from
                 emit.Line(line)
@@ -1281,24 +1483,30 @@ def EmitHelperCode(root, emit, header_file):
         emit.Indent()
         for method in root.Properties():
             if isinstance(method, JsonNotification) and method.StatusListener():
-                emit.Line("RegisterEventStatusListener(_T(\"%s\"), [this](const string& client, Status status) {" % method.JsonName())
+                emit.Line(
+                    "RegisterEventStatusListener(_T(\"%s\"), [this](const string& client, Status status) {" % method.JsonName())
                 emit.Indent()
-                emit.Line("const string id = client.substr(0, client.find('.'));")
+                emit.Line(
+                    "const string id = client.substr(0, client.find('.'));")
                 emit.Line("// TODO...")
                 emit.Unindent()
                 emit.Line("});")
                 emit.Line()
         for method in root.Properties():
             if not isinstance(method, JsonNotification) and not isinstance(method, JsonProperty):
-                line = 'Register<%s,%s>(_T("%s"), &%s::%s, this);' % (method.Properties()[0].CppType(), method.Properties()[1].CppType(), method.JsonName(), root.JsonName(), method.MethodName())
+                line = 'Register<%s,%s>(_T("%s"), &%s::%s, this);' % (method.Properties()[0].CppType(
+                ), method.Properties()[1].CppType(), method.JsonName(), root.JsonName(), method.MethodName())
                 if method.included_from:
                     line += " /* %s */" % method.included_from
                 emit.Line(line)
         for method in root.Properties():
             if isinstance(method, JsonProperty):
-                line = 'Property<%s>(_T("%s")' % (method.Properties()[0].CppType(), method.JsonName())
-                line += ", &%s::%s" % (root.JsonName(), method.GetMethodName()) if not method.writeonly else ", nullptr"
-                line += ", &%s::%s" % (root.JsonName(), method.SetMethodName()) if not method.readonly else ", nullptr"
+                line = 'Property<%s>(_T("%s")' % (method.Properties()[
+                    0].CppType(), method.JsonName())
+                line += ", &%s::%s" % (root.JsonName(), method.GetMethodName()
+                                       ) if not method.writeonly else ", nullptr"
+                line += ", &%s::%s" % (root.JsonName(), method.SetMethodName()
+                                       ) if not method.readonly else ", nullptr"
                 line += ', this);'
                 if method.included_from:
                     line += " /* %s */" % method.included_from
@@ -1317,23 +1525,25 @@ def EmitHelperCode(root, emit, header_file):
                 emit.Line('Unregister(_T("%s"));' % method.JsonName())
         for method in reversed(root.Properties()):
             if isinstance(method, JsonNotification) and method.StatusListener():
-                emit.Line("UnregisterEventStatusListener(_T(\"%s\");" % method.JsonName())
+                emit.Line("UnregisterEventStatusListener(_T(\"%s\");" %
+                          method.JsonName())
 
         emit.Unindent()
         emit.Line("}")
         emit.Line()
 
         # Method/property/event stubs
-        print "Emitting stubs..."
+        print("Emitting stubs...")
         emit.Line("// API implementation")
         emit.Line("//")
         emit.Line()
         for method in root.Properties():
             if not isinstance(method, JsonNotification) and not isinstance(method, JsonProperty):
-                print "Emitting method '%s'" % method.JsonName()
+                print("Emitting method '{}'".format(method.JsonName()))
                 params = method.Properties()[0].CppType()
                 if method.Summary():
-                    emit.Line("// Method: %s - %s" % (method.JsonName(), method.Summary().split(".",1)[0]))
+                    emit.Line("// Method: %s - %s" %
+                              (method.JsonName(), method.Summary().split(".", 1)[0]))
                 emit.Line("// Return codes:")
                 emit.Line("//  - ERROR_NONE: Success")
                 for e in method.Errors():
@@ -1341,11 +1551,12 @@ def EmitHelperCode(root, emit, header_file):
                     if isinstance(e, jsonref.JsonRef) and "description" in e.__reference__:
                         description = e.__reference__["description"]
                     emit.Line("//  - %s: %s" % (e["message"], description))
-                response  = method.Properties()[1].CppType()
-                line = ("uint32_t %s::%s(%s%s%s)" % (root.JsonName(), method.MethodName(), \
-                                ("const " + params + "& params") if params != "void" else "", \
-                                ", " if params != "void" and response != "void" else "", \
-                                (response + "& response") if response != "void" else ""))
+                response = method.Properties()[1].CppType()
+                line = ("uint32_t %s::%s(%s%s%s)" % (root.JsonName(), method.MethodName(),
+                                                     ("const " + params +
+                                                      "& params") if params != "void" else "",
+                                                     ", " if params != "void" and response != "void" else "",
+                                                     (response + "& response") if response != "void" else ""))
                 if method.included_from:
                     line += " /* %s */" % method.included_from
                 emit.Line(line)
@@ -1355,9 +1566,10 @@ def EmitHelperCode(root, emit, header_file):
                 if params != "void":
                     for p in method.Properties()[0].Properties():
                         if not isinstance(p, (JsonObject, JsonArray)):
-                            emit.Line("const %s& %s = params.%s.Value();" % (p.CppStdClass(), p.JsonName(), p.CppName()))
+                            emit.Line("const %s& %s = params.%s.Value();" % (
+                                p.CppStdClass(), p.JsonName(), p.CppName()))
                         else:
-                            emit.Line("// params.%s ..." %p.CppName())
+                            emit.Line("// params.%s ..." % p.CppName())
                 emit.Line()
                 emit.Line("// TODO...")
                 emit.Line()
@@ -1375,7 +1587,8 @@ def EmitHelperCode(root, emit, header_file):
                 def EmitPropertyFc(method, name, getter):
                     params = method.Properties()[0].CppType()
                     if method.Summary():
-                        emit.Line("// Property: %s - %s" % (method.JsonName(), method.Summary().split(".",1)[0]))
+                        emit.Line("// Property: %s - %s" %
+                                  (method.JsonName(), method.Summary().split(".", 1)[0]))
                     emit.Line("// Return codes:")
                     emit.Line("//  - ERROR_NONE: Success")
                     for e in method.Errors():
@@ -1383,7 +1596,8 @@ def EmitHelperCode(root, emit, header_file):
                         if isinstance(e, jsonref.JsonRef) and "description" in e.__reference__:
                             description = e.__reference__["description"]
                         emit.Line("//  - %s: %s" % (e["message"], description))
-                    line = "uint32_t %s::%s(%s%s%s& %s)%s" % (root.JsonName(), name, "const string& index, " if method.has_index else "", "const " if not getter else "", params, "response" if getter else "param", " const" if getter else "")
+                    line = "uint32_t %s::%s(%s%s%s& %s)%s" % (root.JsonName(), name, "const string& index, " if method.has_index else "",
+                                                              "const " if not getter else "", params, "response" if getter else "param", " const" if getter else "")
                     if method.included_from:
                         line += " /* %s */" % method.included_from
                     emit.Line(line)
@@ -1396,11 +1610,15 @@ def EmitHelperCode(root, emit, header_file):
                     else:
                         emit.Line("// response = ...")
                     emit.Line()
-                    emit.Line("return %s;" % ("Core::ERROR_NONE" if getter else "result"))
+                    emit.Line("return %s;" %
+                              ("Core::ERROR_NONE" if getter else "result"))
                     emit.Unindent()
                     emit.Line("}")
                     emit.Line()
-                print "Emitting property '%s'%s" % (method.JsonName(), " (write-only)" if method.writeonly else " (read-only)" if method.readonly else "")
+                propType = ' (write-only)' if method.writeonly else (
+                    ' (read-only)' if method.readonly else '')
+                print("Emitting property '{}' {}".format(
+                    method.JsonName(), propType))
                 if not method.writeonly:
                     EmitPropertyFc(method, method.GetMethodName(), True)
                 if not method.readonly:
@@ -1408,7 +1626,7 @@ def EmitHelperCode(root, emit, header_file):
 
         for method in root.Properties():
             if isinstance(method, JsonNotification):
-                print "Emitting notification '%s'" % method.JsonName()
+                print("Emitting notification '{}'".format(method.JsonName()))
                 EmitEvent(emit, root, method)
 
         emit.Unindent()
@@ -1418,8 +1636,7 @@ def EmitHelperCode(root, emit, header_file):
         emit.Line()
 
 
-
-def EmitObjects(root, emit, emitCommon = False):
+def EmitObjects(root, emit, emitCommon=False):
     global emittedItems
     emittedItems = 0
 
@@ -1430,37 +1647,43 @@ def EmitObjects(root, emit, emitCommon = False):
     def EmitEnum(enum):
         global emittedItems
         emittedItems += 1
-        print "Emitting enum %s" % enum.CppClass()
+        print("Emitting enum {}".format(enum.CppClass()))
         root = enum.parent.parent
         while root.parent:
             root = root.parent
         if enum.Description():
             emit.Line("// " + enum.Description())
-        emit.Line("enum%s %s {" % (" class" if enum.IsStronglyTyped() else "", enum.CppClass()))
+        emit.Line("enum%s %s {" % (
+            " class" if enum.IsStronglyTyped() else "", enum.CppClass()))
         emit.Indent()
         for c, item in enumerate(enum.CppEnumerators()):
-            emit.Line("%s%s%s" % (item.upper(), (" = " + str(enum.CppEnumeratorValues()[c])) if enum.CppEnumeratorValues() else "", "," if not c == len(enum.CppEnumerators()) -1 else ""))
+            emit.Line("%s%s%s" % (item.upper(), (" = " + str(enum.CppEnumeratorValues()
+                                                             [c])) if enum.CppEnumeratorValues() else "", "," if not c == len(enum.CppEnumerators()) - 1 else ""))
         emit.Unindent()
         emit.Line("};")
         emit.Line()
 
-    def EmitClass(jsonObj, allowDup = False):
+    def EmitClass(jsonObj, allowDup=False):
         def EmitInit(jsonObject):
             for prop in jsonObj.Properties():
-                emit.Line("Add(_T(\"%s\"), &%s);" % (prop.JsonName(), prop.CppName()))
+                emit.Line("Add(_T(\"%s\"), &%s);" %
+                          (prop.JsonName(), prop.CppName()))
 
-        def EmitCtor(jsonObj, noInitCode = False, copyCtor = False):
+        def EmitCtor(jsonObj, noInitCode=False, copyCtor=False):
             if copyCtor:
-                emit.Line("%s(const %s& other)" % (jsonObj.CppClass(), jsonObj.CppClass()))
+                emit.Line("%s(const %s& other)" %
+                          (jsonObj.CppClass(), jsonObj.CppClass()))
             else:
                 emit.Line("%s()" % (jsonObj.CppClass()))
             emit.Indent()
             emit.Line(": %s" % TypePrefix("Container()"))
             for prop in jsonObj.Properties():
-               if copyCtor:
-                    emit.Line(", %s(other.%s)" % (prop.CppName(), prop.CppName()))
-               elif prop.CppDefValue() != '""' and prop.CppDefValue() != "":
-                    emit.Line(", %s(%s)" % (prop.CppName(), prop.CppDefValue()))
+                if copyCtor:
+                    emit.Line(", %s(other.%s)" %
+                              (prop.CppName(), prop.CppName()))
+                elif prop.CppDefValue() != '""' and prop.CppDefValue() != "":
+                    emit.Line(", %s(%s)" %
+                              (prop.CppName(), prop.CppDefValue()))
             emit.Unindent()
             emit.Line("{")
             emit.Indent()
@@ -1477,8 +1700,10 @@ def EmitObjects(root, emit, emitCommon = False):
         if jsonObj.IsDuplicate() or (not allowDup and jsonObj.RefCount() > 1):
             return
         if not isinstance(jsonObj, (JsonRpcSchema, JsonMethod)):
-            print "Emitting class '%s' (source: '%s')" % (jsonObj.CppClass(), jsonObj.OrigName())
-            emit.Line("class %s : public %s {" % (jsonObj.CppClass(), TypePrefix("Container")))
+            print("Emitting class '{}' (source: '{}')".format(
+                jsonObj.CppClass(), jsonObj.OrigName()))
+            emit.Line("class %s : public %s {" % (
+                jsonObj.CppClass(), TypePrefix("Container")))
             emit.Line("public:")
             if jsonObj.Enums():
                 for enum in jsonObj.Enums():
@@ -1505,11 +1730,13 @@ def EmitObjects(root, emit, emitCommon = False):
                 EmitCtor(jsonObj, True, True)
                 emit.Line()
                 # Also emit the assignment operator
-                emit.Line("%s& operator=(const %s& rhs)" % (jsonObj.CppClass(), jsonObj.CppClass()))
+                emit.Line("%s& operator=(const %s& rhs)" %
+                          (jsonObj.CppClass(), jsonObj.CppClass()))
                 emit.Line("{")
                 emit.Indent()
                 for prop in jsonObj.Properties():
-                    emit.Line("%s = rhs.%s;" % (prop.CppName(), prop.CppName()))
+                    emit.Line("%s = rhs.%s;" %
+                              (prop.CppName(), prop.CppName()))
                 emit.Line("return (*this);")
                 emit.Unindent()
                 emit.Line("}")
@@ -1525,15 +1752,19 @@ def EmitObjects(root, emit, emitCommon = False):
                 emit.Unindent()
                 emit.Line("}")
             else:
-                emit.Line("%s(const %s&) = delete;" % (jsonObj.CppClass(), jsonObj.CppClass()))
-                emit.Line("%s& operator=(const %s&) = delete;" % (jsonObj.CppClass(), jsonObj.CppClass()))
+                emit.Line("%s(const %s&) = delete;" %
+                          (jsonObj.CppClass(), jsonObj.CppClass()))
+                emit.Line("%s& operator=(const %s&) = delete;" %
+                          (jsonObj.CppClass(), jsonObj.CppClass()))
             emit.Line()
             emit.Unindent()
             emit.Line("public:")
             emit.Indent()
             for prop in jsonObj.Properties():
-                comment = prop.OrigName() if isinstance(prop, JsonMethod) else prop.Description()
-                emit.Line("%s %s;%s" % (prop.CppType(), prop.CppName(), (" // " + comment) if comment else ""))
+                comment = prop.OrigName() if isinstance(
+                    prop, JsonMethod) else prop.Description()
+                emit.Line("%s %s;%s" % (prop.CppType(), prop.CppName(),
+                                        (" // " + comment) if comment else ""))
             emit.Unindent()
             emit.Line("}; // class %s" % jsonObj.CppClass())
             emit.Line()
@@ -1560,7 +1791,7 @@ def EmitObjects(root, emit, emitCommon = False):
     emit.Indent()
     emit.Line()
     if emitCommon and enumTracker.CommonObjects():
-        print "Emitting common enums..."
+        print("Emitting common enums...")
         emit.Line("// Common enums")
         emit.Line("//")
         emit.Line()
@@ -1568,7 +1799,7 @@ def EmitObjects(root, emit, emitCommon = False):
             if not obj.IsDuplicate() and not obj.included_from:
                 EmitEnum(obj)
     if emitCommon and objTracker.CommonObjects():
-        print "Emitting common classes..."
+        print("Emitting common classes...")
         emit.Line("// Common classes")
         emit.Line("//")
         emit.Line()
@@ -1576,7 +1807,7 @@ def EmitObjects(root, emit, emitCommon = False):
             if not obj.included_from:
                 EmitClass(obj, True)
     if root.Objects():
-        print "Emitting params/result classes..."
+        print("Emitting params/result classes...")
         emit.Line("// Method params/result classes")
         emit.Line("//")
         emit.Line()
@@ -1597,12 +1828,15 @@ def EmitObjects(root, emit, emitCommon = False):
     emit.Line()
     return emittedItems
 
+
 def CreateCode(schema, path, generateClasses, generateStubs, generateRpc):
     directory = os.path.dirname(path)
-    filename = (schema["info"]["class"]) if "info" in schema and "class" in schema["info"] else os.path.basename(path.replace("Plugin", "").replace(".json", "").replace(".h",""))
+    filename = (schema["info"]["class"]) if "info" in schema and "class" in schema["info"] else os.path.basename(
+        path.replace("Plugin", "").replace(".json", "").replace(".h", ""))
     rpcObj = ParseJsonRpcSchema(schema)
     if rpcObj:
-        header_file = os.path.join(directory, DATA_NAMESPACE + "_" + filename + ".h")
+        header_file = os.path.join(
+            directory, DATA_NAMESPACE + "_" + filename + ".h")
         enum_file = os.path.join(directory, "JsonEnum_" + filename + ".cpp")
 
         if generateClasses:
@@ -1610,16 +1844,21 @@ def CreateCode(schema, path, generateClasses, generateStubs, generateRpc):
             with open(header_file, "w") as output_file:
                 emitter = Emitter(output_file, INDENT_SIZE)
                 emitter.Line()
-                emitter.Line("// C++ classes for %s JSON-RPC API." % rpcObj.info["title"].replace("Plugin", "").strip())
-                emitter.Line("// Generated automatically from '%s'." % os.path.basename(path))
+                emitter.Line("// C++ classes for %s JSON-RPC API." %
+                             rpcObj.info["title"].replace("Plugin", "").strip())
+                emitter.Line("// Generated automatically from '%s'." %
+                             os.path.basename(path))
                 emitter.Line()
-                emitter.Line("// Note: This code is inherently not thread safe. If required, proper synchronisation must be added.")
+                emitter.Line(
+                    "// Note: This code is inherently not thread safe. If required, proper synchronisation must be added.")
                 emitter.Line()
                 emitted = EmitObjects(rpcObj, emitter, True)
                 if emitted:
-                    trace.Success("JSON data classes generated in '%s'." % output_file.name)
+                    trace.Success(
+                        "JSON data classes generated in '%s'." % output_file.name)
                 else:
-                    trace.Success("No JSON data classes generated for '%s'." % filename)
+                    trace.Success(
+                        "No JSON data classes generated for '%s'." % filename)
             if not emitted and not KEEP_EMPTY:
                 try:
                     os.remove(header_file)
@@ -1629,14 +1868,18 @@ def CreateCode(schema, path, generateClasses, generateStubs, generateRpc):
             with open(enum_file, "w") as output_file:
                 emitter = Emitter(output_file, INDENT_SIZE)
                 emitter.Line()
-                emitter.Line("// Enumeration code for %s JSON-RPC API." % rpcObj.info["title"].replace("Plugin", "").strip())
-                emitter.Line("// Generated automatically from '%s'." % os.path.basename(path))
+                emitter.Line("// Enumeration code for %s JSON-RPC API." %
+                             rpcObj.info["title"].replace("Plugin", "").strip())
+                emitter.Line("// Generated automatically from '%s'." %
+                             os.path.basename(path))
                 emitter.Line()
                 emitted = EmitEnumRegs(rpcObj, emitter, filename)
                 if emitted:
-                    trace.Success("JSON enumeration code generated in '%s'." % output_file.name)
+                    trace.Success(
+                        "JSON enumeration code generated in '%s'." % output_file.name)
                 else:
-                    trace.Success("No JSON enumeration code generated for '%s'." % filename)
+                    trace.Success(
+                        "No JSON enumeration code generated for '%s'." % filename)
             if not emitted and not KEEP_EMPTY:
                 try:
                     os.remove(enum_file)
@@ -1648,14 +1891,16 @@ def CreateCode(schema, path, generateClasses, generateStubs, generateRpc):
                 emitter = Emitter(output_file, INDENT_SIZE)
                 emitter.Line()
                 EmitHelperCode(rpcObj, emitter, os.path.basename(header_file))
-                trace.Success("JSON-RPC stubs generated in '%s'." % output_file.name)
+                trace.Success("JSON-RPC stubs generated in '%s'." %
+                              output_file.name)
 
         if generateRpc and "dorpc" in rpcObj.schema and rpcObj.schema["dorpc"] == True:
             with open(os.path.join(directory, "J" + filename + ".h"), "w") as output_file:
                 emitter = Emitter(output_file, INDENT_SIZE)
                 emitter.Line()
                 EmitRpcCode(rpcObj, emitter, filename, os.path.basename(path))
-                trace.Success("JSON-RPC implementation generated in '%s'." % output_file.name)
+                trace.Success(
+                    "JSON-RPC implementation generated in '%s'." % output_file.name)
 
     else:
         trace.Success("No code to generate.")
@@ -1666,7 +1911,8 @@ def CreateCode(schema, path, generateClasses, generateStubs, generateRpc):
 #
 
 def CreateDocument(schema, path):
-    output_path = os.path.dirname(path) + "/" + os.path.basename(path).replace(".json","") + ".md"
+    output_path = os.path.dirname(
+        path) + "/" + os.path.basename(path).replace(".json", "") + ".md"
     with open(output_path, "w") as output_file:
         emit = Emitter(output_file, INDENT_SIZE)
 
@@ -1684,10 +1930,12 @@ def CreateDocument(schema, path):
 
         def MdHeader(string, level=1, id="head", include=None):
             if level < 3:
-                emit.Line("<a name=\"%s\"></a>" % (id + "." + string.replace(" ", "_")))
+                emit.Line("<a name=\"%s\"></a>" %
+                          (id + "." + string.replace(" ", "_")))
             if id != "head":
                 string += " <sup>%s</sup>" % id
-            emit.Line("%s %s" % ("#"*level, "*%s*" % string if id != "head" else string))
+            emit.Line("%s %s" % ("#" * level, "*%s*" %
+                                 string if id != "head" else string))
             MdBr()
 
         def MdBody(string=""):
@@ -1714,15 +1962,19 @@ def CreateDocument(schema, path):
 
         def ParamTable(name, object):
             MdTableHeader(["Name", "Type", "Description"])
-            def __TableObj(name, obj, parentName = "", parent=None, prefix="", parentOptional=False):
+
+            def __TableObj(name, obj, parentName="", parent=None, prefix="", parentOptional=False):
                 # determine if the attribute is optional
-                optional = parentOptional or (obj["optional"] if "optional" in obj else False)
+                optional = parentOptional or (
+                    obj["optional"] if "optional" in obj else False)
                 if parent and not optional:
                     if parent["type"] == "object":
-                        optional = ("required" not in parent and len(parent["properties"]) > 1) or ("required" in parent and name not in parent["required"]) or ("required" in parent and len(parent["required"])==0)
+                        optional = ("required" not in parent and len(parent["properties"]) > 1) or (
+                            "required" in parent and name not in parent["required"]) or ("required" in parent and len(parent["required"]) == 0)
 
-                #include information about enum values in description
-                enum = ' (must be one of the following: %s)' % (", ".join('*{0}*'.format(w) for w in obj["enum"])) if "enum" in obj else ""
+                # include information about enum values in description
+                enum = ' (must be one of the following: %s)' % (
+                    ", ".join('*{0}*'.format(w) for w in obj["enum"])) if "enum" in obj else ""
                 if parent and prefix and parent["type"] == "object":
                     prefix += "?." if optional else "."
                 prefix += name
@@ -1731,18 +1983,23 @@ def CreateDocument(schema, path):
                     description = obj.__reference__["description"]
                 if name or prefix:
                     if "type" not in obj:
-                        raise RuntimeError("missing 'type' for object %s" % (parentName+"/"+name))
-                    row = (("<sup>"+italics("(optional)") + "</sup>" +" ") if optional else "") + description + enum
+                        raise RuntimeError(
+                            "missing 'type' for object %s" % (parentName + "/" + name))
+                    row = (("<sup>" + italics("(optional)") + "</sup>" + " ")
+                           if optional else "") + description + enum
                     if row.endswith('.'):
                         row = row[:-1]
                     MdRow([prefix, obj["type"], row])
                 if obj["type"] == "object":
                     if "required" not in obj and name and len(obj["properties"]) > 1:
-                        trace.Warn('No "required" field for object "%s"' % name)
-                    for pname, props in obj["properties"].iteritems():
-                        __TableObj(pname, props, parentName+"/"+name, obj, prefix, False)
+                        trace.Warn(
+                            'No "required" field for object "%s"' % name)
+                    for pname, props in obj["properties"].items():
+                        __TableObj(pname, props, parentName +
+                                   "/" + name, obj, prefix, False)
                 elif obj["type"] == "array":
-                    __TableObj("", obj["items"], parentName+"/"+name, obj, (prefix + "[#]") if name else "", optional)
+                    __TableObj("", obj["items"], parentName + "/" + name,
+                               obj, (prefix + "[#]") if name else "", optional)
             __TableObj(name, object, "")
             MdBr()
 
@@ -1752,13 +2009,15 @@ def CreateDocument(schema, path):
                 description = err["description"] if "description" in err else ""
                 if isinstance(err, jsonref.JsonRef) and "description" in err.__reference__:
                     description = err.__reference__["description"]
-                MdRow([err["code"] if "code" in err else "", "```"+err["message"]+"```", description])
+                MdRow([err["code"] if "code" in err else "",
+                       "```" + err["message"] + "```", description])
             MdBr()
 
         def PlainTable(obj, columns, ref="ref"):
             MdTableHeader(columns)
-            for prop,val in sorted(obj.iteritems()):
-                MdRow(["<a name=\"%s.%s\">%s</a>" % (ref, (prop.split("]",1)[0][1:]) if "]" in prop else prop, prop), val])
+            for prop, val in sorted(obj.items()):
+                MdRow(["<a name=\"%s.%s\">%s</a>" % (ref, (prop.split("]", 1)
+                                                           [0][1:]) if "]" in prop else prop, prop), val])
             MdBr()
 
         def __ExampleObj(name, obj):
@@ -1776,20 +2035,26 @@ def CreateDocument(schema, path):
             elif objType == "null":
                 jsonData += 'null'
             elif objType == "array":
-                jsonData += str(default if default else ('[ %s ]' % (__ExampleObj("", obj["items"]))))
+                jsonData += str(default if default else (
+                    '[ %s ]' % (__ExampleObj("", obj["items"]))))
             elif objType == "object":
-                jsonData += "{ %s }" % ", ".join(map(lambda p: __ExampleObj(p, obj["properties"][p]), obj["properties"])[0:obj["maxProperties"] if "maxProperties" in obj else None])
+                jsonData += "{ %s }" % ", ".join(list(map(lambda p: __ExampleObj(p, obj["properties"][p]), obj["properties"]))[
+                                                 0:obj["maxProperties"] if "maxProperties" in obj else None])
             return jsonData
 
         def MethodDump(method, props, classname, is_notification=False, is_property=False, include=None):
-            method = (method.rsplit(".", 1)[1] if "." in method else method).lower()
-            MdHeader(method, 2, "property" if is_property else "event" if is_notification else "method", include)
+            method = (method.rsplit(".", 1)[
+                      1] if "." in method else method).lower()
+            MdHeader(
+                method, 2, "property" if is_property else "event" if is_notification else "method", include)
             readonly = False
             writeonly = False
             if "summary" in props:
                 text = props["summary"]
                 if is_property:
-                    text = "Provides access to the " + (text[0].lower() if text[1].islower() else text[0]) + text[1:]
+                    text = "Provides access to the " + \
+                        (text[0].lower() if text[1].islower()
+                         else text[0]) + text[1:]
                 if not text.endswith('.'):
                     text += '.'
                 MdParagraph(text)
@@ -1804,7 +2069,8 @@ def CreateDocument(schema, path):
                 MdHeader("Description", 3)
                 MdParagraph(props["description"])
             if "events" in props:
-                MdParagraph("Also see: " + (", ".join(map(lambda x: link("event." + x), props["events"]))))
+                MdParagraph(
+                    "Also see: " + (", ".join(map(lambda x: link("event." + x), props["events"]))))
             if is_property:
                 MdHeader("Value", 3)
                 if not "description" in props["params"]:
@@ -1812,8 +2078,10 @@ def CreateDocument(schema, path):
                 ParamTable("(property)", props["params"])
                 if "index" in props:
                     if "name" not in props["index"] or "example" not in props["index"]:
-                        raise RuntimeError("in %s: index field needs 'name' and 'example' properties" % method)
-                    extra_paragraph = "> The *%s* shall be passed as the index to the property, e.g. *%s.1.%s@%s*.%s" % (props["index"]["name"].lower(), classname, method, props["index"]["example"], (" " + props["index"]["description"]) if "description" in props["index"] else "")
+                        raise RuntimeError(
+                            "in %s: index field needs 'name' and 'example' properties" % method)
+                    extra_paragraph = "> The *%s* shall be passed as the index to the property, e.g. *%s.1.%s@%s*.%s" % (props["index"]["name"].lower(
+                    ), classname, method, props["index"]["example"], (" " + props["index"]["description"]) if "description" in props["index"] else "")
                     if not extra_paragraph.endswith('.'):
                         extra_paragraph += '.'
                     MdParagraph(extra_paragraph)
@@ -1829,8 +2097,10 @@ def CreateDocument(schema, path):
                 if is_notification:
                     if "id" in props:
                         if "name" not in props["id"] or "example" not in props["id"]:
-                            raise RuntimeError("in %s: id field needs 'name' and 'example' properties" % method)
-                        MdParagraph("> The *%s* shall be passed within the designator, e.g. *%s.client.events.1*." % (props["id"]["name"], props["id"]["example"]))
+                            raise RuntimeError(
+                                "in %s: id field needs 'name' and 'example' properties" % method)
+                        MdParagraph("> The *%s* shall be passed within the designator, e.g. *%s.client.events.1*." % (
+                            props["id"]["name"], props["id"]["example"]))
 
             if "result" in props:
                 MdHeader("Result", 3)
@@ -1844,20 +2114,23 @@ def CreateDocument(schema, path):
             if is_notification:
                 method = "client.events.1." + method
             elif is_property:
-                method = "%s.1.%s%s" % (classname, method, ("@" + props["index"]["example"]) if "index" in props and "example" in props["index"] else "")
+                method = "%s.1.%s%s" % (
+                    classname, method, ("@" + props["index"]["example"]) if "index" in props and "example" in props["index"] else "")
             else:
                 method = "%s.1.%s" % (classname, method)
             if "id" in props and "example" in props["id"]:
                 method = props["id"]["example"] + "." + method
-            parameters =  props["params"] if "params" in props else None
+            parameters = props["params"] if "params" in props else None
 
             if is_property:
                 if not writeonly:
                     MdHeader("Get Request", 4)
-                    jsonRequest = json.dumps(json.loads('{ "jsonrpc": "2.0", "id": 1234567890, "method": "%s" }' % method, object_pairs_hook=OrderedDict), indent=4)
+                    jsonRequest = json.dumps(json.loads(
+                        '{ "jsonrpc": "2.0", "id": 1234567890, "method": "%s" }' % method, object_pairs_hook=OrderedDict), indent=4)
                     MdCode(jsonRequest, "json")
                     MdHeader("Get Response", 4)
-                    jsonResponse = json.dumps(json.loads('{ "jsonrpc": "2.0", "id": 1234567890, %s }' % __ExampleObj("result", parameters), object_pairs_hook=OrderedDict), indent=4)
+                    jsonResponse = json.dumps(json.loads('{ "jsonrpc": "2.0", "id": 1234567890, %s }' % __ExampleObj(
+                        "result", parameters), object_pairs_hook=OrderedDict), indent=4)
                     MdCode(jsonResponse, "json")
 
             if not readonly:
@@ -1867,20 +2140,23 @@ def CreateDocument(schema, path):
                     else:
                         MdHeader("Request", 4)
 
-                jsonRequest = json.dumps(json.loads('{ "jsonrpc": "2.0", %s"method": "%s"%s }' % ('"id": 1234567890, ' if not is_notification else "", method, (", " + __ExampleObj("params", parameters)) if parameters else ""), object_pairs_hook=OrderedDict), indent=4)
+                jsonRequest = json.dumps(json.loads('{ "jsonrpc": "2.0", %s"method": "%s"%s }' % ('"id": 1234567890, ' if not is_notification else "", method, (
+                    ", " + __ExampleObj("params", parameters)) if parameters else ""), object_pairs_hook=OrderedDict), indent=4)
                 MdCode(jsonRequest, "json")
 
                 if not is_notification and not is_property:
                     if "result" in props:
                         MdHeader("Response", 4)
-                        jsonResponse = json.dumps(json.loads('{ "jsonrpc": "2.0", "id": 1234567890, %s }' % __ExampleObj("result", props["result"]), object_pairs_hook=OrderedDict), indent=4)
+                        jsonResponse = json.dumps(json.loads('{ "jsonrpc": "2.0", "id": 1234567890, %s }' % __ExampleObj(
+                            "result", props["result"]), object_pairs_hook=OrderedDict), indent=4)
                         MdCode(jsonResponse, "json")
                     elif "noresult" not in props or not props["noresult"]:
                         raise RuntimeError("missing 'result' in %s" % method)
 
                 if is_property:
                     MdHeader("Set Response", 4)
-                    jsonResponse = json.dumps(json.loads('{ "jsonrpc": "2.0", "id": 1234567890, "result": "null" }', object_pairs_hook=OrderedDict), indent=4)
+                    jsonResponse = json.dumps(json.loads(
+                        '{ "jsonrpc": "2.0", "id": 1234567890, "result": "null" }', object_pairs_hook=OrderedDict), indent=4)
                     MdCode(jsonResponse, "json")
 
         MdBody("<!-- Generated automatically, DO NOT EDIT! -->")
@@ -1904,7 +2180,7 @@ def CreateDocument(schema, path):
         if "events" in interface:
             event_count = len(interface["events"])
         if "include" in interface:
-            for name, iface in interface["include"].iteritems():
+            for _, iface in interface["include"].items():
                 if "methods" in iface:
                     method_count += len(iface["methods"])
                 if "properties" in iface:
@@ -1929,7 +2205,8 @@ def CreateDocument(schema, path):
             rating = 3
         else:
             raise RuntimeError("invalid status")
-        MdParagraph(bold("Status: " + rating*":black_circle:" + (3-rating)*":white_circle:"))
+        MdParagraph(bold("Status: " + rating * ":black_circle:" +
+                         (3 - rating) * ":white_circle:"))
 
         plugin_class = None
         if "class" in info:
@@ -1941,7 +2218,7 @@ def CreateDocument(schema, path):
 
         MdParagraph("%s plugin for Thunder framework." % plugin_class)
 
-        MdHeader("Table of Contents",3)
+        MdHeader("Table of Contents", 3)
         MdBody("- " + link("head.Introduction"))
         if "description" in info:
             MdBody("- " + link("head.Description"))
@@ -1955,7 +2232,7 @@ def CreateDocument(schema, path):
         MdBr()
 
         def mergedict(d1, d2, prop):
-            return dict((d1[prop] if prop in d1 else dict()).items() + (d2[prop] if prop in d2 else dict()).items())
+            return {**(d1[prop] if prop in d1 else dict()), **(d2[prop] if prop in d2 else dict())}
 
         MdHeader("Introduction")
         MdHeader("Scope", 2)
@@ -1977,51 +2254,66 @@ def CreateDocument(schema, path):
                 extra = " and properties provided"
             elif event_count:
                 extra = " and notifications sent"
-            MdParagraph("This document describes purpose and functionality of the %s plugin. It includes detailed specification of its configuration%s." % (plugin_class, extra))
+            MdParagraph("This document describes purpose and functionality of the %s plugin. It includes detailed specification of its configuration%s." % (
+                plugin_class, extra))
 
-        MdHeader("Case Sensitivity",2)
+        MdHeader("Case Sensitivity", 2)
         MdParagraph("All identifiers on the interface described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such.")
         if "acronyms" in info or "acronyms" in commons or "terms" in info or "terms" in commons:
-            MdHeader("Acronyms, Abbreviations and Terms",2)
+            MdHeader("Acronyms, Abbreviations and Terms", 2)
             if "acronyms" in info or "acronyms" in commons:
-                MdParagraph("The table below provides and overview of acronyms used in this document and their definitions.")
-                PlainTable(mergedict(commons, info, "acronyms"), ["Acronym", "Description"], "acronym")
+                MdParagraph(
+                    "The table below provides and overview of acronyms used in this document and their definitions.")
+                PlainTable(mergedict(commons, info, "acronyms"),
+                           ["Acronym", "Description"], "acronym")
             if "terms" in info or "terms" in commons:
-                MdParagraph("The table below provides and overview of terms and abbreviations used in this document and their definitions.")
-                PlainTable(mergedict(commons, info, "terms"), ["Term", "Description"], "term")
+                MdParagraph(
+                    "The table below provides and overview of terms and abbreviations used in this document and their definitions.")
+                PlainTable(mergedict(commons, info, "terms"),
+                           ["Term", "Description"], "term")
 
         if "standards" in info:
-            MdHeader("Standards",2)
+            MdHeader("Standards", 2)
             MdParagraph(info["standards"])
 
         if "references" in commons or "references" in info:
-            MdHeader("References",2)
-            PlainTable(mergedict(commons, info, "references"), ["Ref ID", "Description"])
+            MdHeader("References", 2)
+            PlainTable(mergedict(commons, info, "references"),
+                       ["Ref ID", "Description"])
 
         if "description" in info:
             MdHeader("Description")
-            MdParagraph(" ".join(info["description"]) if isinstance(info["description"], list) else info["description"])
-            MdParagraph("The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)].")
+            MdParagraph(" ".join(info["description"]) if isinstance(
+                info["description"], list) else info["description"])
+            MdParagraph(
+                "The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)].")
 
         MdHeader("Configuration")
         commonConfig = OrderedDict()
         if "configuration" in schema and "nodefault" in schema["configuration"] and schema["configuration"]["nodefault"] and "properties" not in schema["configuration"]:
             MdParagraph("The plugin does not take any configuration.")
         else:
-            MdParagraph("The table below lists configuration options of the plugin.")
+            MdParagraph(
+                "The table below lists configuration options of the plugin.")
             if "configuration" not in schema or ("nodefault" not in schema["configuration"] or not schema["configuration"]["nodefault"]):
                 if "callsign" in info:
-                    commonConfig["callsign"] = { "type": "string", "description": 'Plugin instance name (default: *%s*)' % info["callsign"] }
+                    commonConfig["callsign"] = {
+                        "type": "string", "description": 'Plugin instance name (default: *%s*)' % info["callsign"]}
                 if plugin_class:
-                    commonConfig["classname"] = { "type": "string", "description": 'Class name: *%s*' % plugin_class }
+                    commonConfig["classname"] = {
+                        "type": "string", "description": 'Class name: *%s*' % plugin_class}
                 if "locator" in info:
-                    commonConfig["locator"] = { "type": "string", "description":  'Library name: *%s*' % info["locator"] }
-                commonConfig["autostart"] = {"type": "boolean", "description": "Determines if the plugin is to be started automatically along with the framework" }
+                    commonConfig["locator"] = {
+                        "type": "string", "description": 'Library name: *%s*' % info["locator"]}
+                commonConfig["autostart"] = {
+                    "type": "boolean", "description": "Determines if the plugin is to be started automatically along with the framework"}
 
             required = []
             if "configuration" in schema:
-                commonConfig2 = OrderedDict(commonConfig.items() + schema["configuration"]["properties"].items())
-                required = schema["configuration"]["required"] if "required" in schema["configuration"] else []
+                commonConfig2 = OrderedDict(commonConfig.items(
+                ) + schema["configuration"]["properties"].items())
+                required = schema["configuration"]["required"] if "required" in schema["configuration"] else [
+                ]
             else:
                 commonConfig2 = commonConfig
 
@@ -2029,7 +2321,8 @@ def CreateDocument(schema, path):
             totalConfig["type"] = "object"
             totalConfig["properties"] = commonConfig2
             if "configuration" not in schema or ("nodefault" not in schema["configuration"] or not schema["configuration"]["nodefault"]):
-               totalConfig["required"] = ["callsign", "classname", "locator", "autostart"] + required
+                totalConfig["required"] = ["callsign",
+                                           "classname", "locator", "autostart"] + required
 
             ParamTable("", totalConfig)
 
@@ -2039,11 +2332,13 @@ def CreateDocument(schema, path):
             def InterfaceDump(interface, section, header):
                 head = False
                 if section in interface:
-                    for method, contents in interface[section].iteritems():
+                    for method, contents in interface[section].items():
                         if contents and method not in skip_list:
                             if not head:
-                                MdParagraph("%s interface %s:" % (interface["info"]["class"], section))
-                                MdTableHeader([header.capitalize(), "Description"])
+                                MdParagraph("%s interface %s:" % (
+                                    interface["info"]["class"], section))
+                                MdTableHeader(
+                                    [header.capitalize(), "Description"])
                                 head = True
                             access = ""
                             if "readonly" in contents and contents["readonly"] == True:
@@ -2059,18 +2354,21 @@ def CreateDocument(schema, path):
                                     descr = descr[0:descr.index("e.g") - 1]
                                 if "i.e" in descr:
                                     descr = descr[0:descr.index("i.e") - 1]
-                                descr = descr.split(".",1)[0] if "." in descr else descr
-                            MdRow([link(header + "." + (method.rsplit(".", 1)[1] if "." in method else method)) + access, descr])
+                                descr = descr.split(
+                                    ".", 1)[0] if "." in descr else descr
+                            MdRow([link(header + "." + (method.rsplit(".", 1)[1]
+                                                        if "." in method else method)) + access, descr])
                         skip_list.append(method)
 
             MdHeader(section_name)
             if description:
                 MdParagraph(description)
 
-            MdParagraph("The following %s are provided by the %s plugin:" % (section, plugin_class))
+            MdParagraph("The following %s are provided by the %s plugin:" % (
+                section, plugin_class))
             InterfaceDump(interface, section, header)
             if "include" in interface:
-                for name, s in interface["include"].iteritems():
+                for _, s in interface["include"].items():
                     if s:
                         if section in s:
                             MdBr()
@@ -2083,19 +2381,20 @@ def CreateDocument(schema, path):
             skip_list = []
 
             if section in interface:
-                for method, props in interface[section].iteritems():
+                for method, props in interface[section].items():
                     if props:
                         MethodDump(method, props, plugin_class, event, prop)
                     skip_list.append(method)
 
             if "include" in interface:
-                for name, s in interface["include"].iteritems():
+                for _, s in interface["include"].items():
                     if s:
                         cl = s["info"]["class"]
                         if section in s:
-                            for method, props in s[section].iteritems():
+                            for method, props in s[section].items():
                                 if props and method not in skip_list:
-                                    MethodDump(method, props, plugin_class, event, prop, cl)
+                                    MethodDump(method, props,
+                                               plugin_class, event, prop, cl)
 
         if method_count:
             SectionDump("Methods", "methods", "method")
@@ -2104,37 +2403,54 @@ def CreateDocument(schema, path):
             SectionDump("Properties", "properties", "property", prop=True)
 
         if event_count:
-            SectionDump("Notifications", "events", "event", "Notifications are autonomous events, triggered by the internals of the plugin, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.", event=True)
+            SectionDump("Notifications", "events", "event",
+                        "Notifications are autonomous events, triggered by the internals of the plugin, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.", event=True)
 
         trace.Success("Document created: %s" % output_path)
 
 
-
 # -------------------------------------------------------------------------
 # entry point
-
 objTracker = ObjectTracker()
 enumTracker = EnumTracker()
 
 if __name__ == "__main__":
-    argparser = argparse.ArgumentParser(description='Generate JSON C++ classes, stub code and API documentation from JSON definition files.', formatter_class=argparse.RawTextHelpFormatter )
-    argparser.add_argument('path', nargs="*", help="JSON file(s), wildcards are allowed")
-    argparser.add_argument("--version", dest="version", action="store_true", default=False, help="display version")
-    argparser.add_argument("-d", "--docs", dest="docs", action="store_true", default=False, help="generate documentation")
-    argparser.add_argument("-c", "--code", dest="code", action="store_true", default=False, help="generate JSON classes and JSON-RPC code if applicable")
-    argparser.add_argument("-s", "--stubs", dest="stubs", action="store_true", default=False, help="generate JSON-RPC stub code")
-    argparser.add_argument("-p", dest="if_path",  metavar="PATH", action="store", type=str, default=IF_PATH, help="relative path for #include'ing JsonData header file (default: 'interfaces/json', '.' for no path)")
-    argparser.add_argument("-i", dest="if_dir", metavar="DIR", action="store", type=str, default=None, help="a directory with JSON API interfaces that will substitute the {interfacedir} tag (default: same directory as source file)")
-    argparser.add_argument("-j", dest="cppif_dir", metavar="DIR", action="store", type=str, default=None, help="a directory with C++ API interfaces that will substitute the {cppinterfacedir} tag (default: same directory as source file)")
-    argparser.add_argument("-o", "--output", dest="output_dir",  metavar="DIR", action="store", default=None, help="output directory, absolute path or directory relative to output file(default: output in the same directory as the source json)")
-    argparser.add_argument("--indent", dest="indent_size", metavar="SIZE", type=int, action="store", default=INDENT_SIZE, help="code indentation in spaces (default: %i)" % INDENT_SIZE)
-    argparser.add_argument("--dump-json", dest="dump_json", action="store_true", default=False, help="dump intermediate JSON file when parsing C++ header")
-    argparser.add_argument("--copy-ctor", dest="copy_ctor", action="store_true", default=False, help="always emit a copy constructor and assignment operator for a class (default: emit only when it appears to be needed)")
-    argparser.add_argument("--keep-empty", dest="keep_empty", action="store_true", default=False, help="keep generated files that have no content (default: remove empty cpp/h files)")
-    argparser.add_argument("--no-ref-names", dest="no_ref_names", action="store_true", default=False, help="do not derive class names from $refs (default: derive class names from $ref)")
-    argparser.add_argument("--def-string", dest="def_string", metavar="STRING", type=str, action="store", default=DEFAULT_EMPTY_STRING, help="default string initialisation (default: \"%s\")" % DEFAULT_EMPTY_STRING)
-    argparser.add_argument("--def-int-size", dest="def_int_size", metavar="SIZE", type=int, action="store", default=DEFAULT_INT_SIZE, help="default integer size in bits (default: %i)" % DEFAULT_INT_SIZE)
-    argparser.add_argument("--no-warnings", dest="no_warnings", action="store_true", default=False, help="suppress style/wording warnings (default: show all warnings)")
+    argparser = argparse.ArgumentParser(
+        description='Generate JSON C++ classes, stub code and API documentation from JSON definition files.', formatter_class=argparse.RawTextHelpFormatter)
+    argparser.add_argument(
+        'path', nargs="*", help="JSON file(s), wildcards are allowed")
+    argparser.add_argument("--version", dest="version",
+                           action="store_true", default=False, help="display version")
+    argparser.add_argument("-d", "--docs", dest="docs", action="store_true",
+                           default=False, help="generate documentation")
+    argparser.add_argument("-c", "--code", dest="code", action="store_true",
+                           default=False, help="generate JSON classes and JSON-RPC code if applicable")
+    argparser.add_argument("-s", "--stubs", dest="stubs", action="store_true",
+                           default=False, help="generate JSON-RPC stub code")
+    argparser.add_argument("-p", dest="if_path", metavar="PATH", action="store", type=str, default=IF_PATH,
+                           help="relative path for #include'ing JsonData header file (default: 'interfaces/json', '.' for no path)")
+    argparser.add_argument("-i", dest="if_dir", metavar="DIR", action="store", type=str, default=None,
+                           help="a directory with JSON API interfaces that will substitute the {interfacedir} tag (default: same directory as source file)")
+    argparser.add_argument("-j", dest="cppif_dir", metavar="DIR", action="store", type=str, default=None,
+                           help="a directory with C++ API interfaces that will substitute the {cppinterfacedir} tag (default: same directory as source file)")
+    argparser.add_argument("-o", "--output", dest="output_dir", metavar="DIR", action="store", default=None,
+                           help="output directory, absolute path or directory relative to output file(default: output in the same directory as the source json)")
+    argparser.add_argument("--indent", dest="indent_size", metavar="SIZE", type=int, action="store",
+                           default=INDENT_SIZE, help="code indentation in spaces (default: %i)" % INDENT_SIZE)
+    argparser.add_argument("--dump-json", dest="dump_json", action="store_true",
+                           default=False, help="dump intermediate JSON file when parsing C++ header")
+    argparser.add_argument("--copy-ctor", dest="copy_ctor", action="store_true", default=False,
+                           help="always emit a copy constructor and assignment operator for a class (default: emit only when it appears to be needed)")
+    argparser.add_argument("--keep-empty", dest="keep_empty", action="store_true", default=False,
+                           help="keep generated files that have no content (default: remove empty cpp/h files)")
+    argparser.add_argument("--no-ref-names", dest="no_ref_names", action="store_true", default=False,
+                           help="do not derive class names from $refs (default: derive class names from $ref)")
+    argparser.add_argument("--def-string", dest="def_string", metavar="STRING", type=str, action="store",
+                           default=DEFAULT_EMPTY_STRING, help="default string initialisation (default: \"%s\")" % DEFAULT_EMPTY_STRING)
+    argparser.add_argument("--def-int-size", dest="def_int_size", metavar="SIZE", type=int, action="store",
+                           default=DEFAULT_INT_SIZE, help="default integer size in bits (default: %i)" % DEFAULT_INT_SIZE)
+    argparser.add_argument("--no-warnings", dest="no_warnings", action="store_true",
+                           default=False, help="suppress style/wording warnings (default: show all warnings)")
     args = argparser.parse_args(sys.argv[1:])
     VERIFY = not args.no_warnings
     INDENT_SIZE = args.indent_size
@@ -2159,7 +2475,7 @@ if __name__ == "__main__":
     generateStubs = args.stubs
 
     if args.version:
-        print "Version: %s" % VERSION
+        print("Version: {}".format(VERSION))
         sys.exit(1)
     elif not args.path or (not generateCode and not generateRpc and not generateStubs and not generateDocs):
         argparser.print_help()
@@ -2173,23 +2489,29 @@ if __name__ == "__main__":
                 if path.endswith(".h"):
                     schemas = LoadInterface(path)
                 else:
-                    schemas = [ LoadSchema(path, args.if_dir, args.cppif_dir) ]
+                    schemas = [LoadSchema(path, args.if_dir, args.cppif_dir)]
                 for schema in schemas:
                     if schema:
                         output_path = path
                         if args.output_dir:
                             if (args.output_dir[0]) == '/':
-                                output_path = os.path.join(args.output_dir, os.path.basename(output_path))
+                                output_path = os.path.join(
+                                    args.output_dir, os.path.basename(output_path))
                             else:
-                                dir = os.path.join(os.path.dirname(output_path), args.output_dir)
+                                dir = os.path.join(os.path.dirname(
+                                    output_path), args.output_dir)
                                 if not os.path.exists(dir):
                                     os.makedirs(dir)
-                                output_path = os.path.join(dir, os.path.basename(output_path))
+                                output_path = os.path.join(
+                                    dir, os.path.basename(output_path))
                         if generateCode or generateStubs or generateRpc:
-                            CreateCode(schema, output_path, generateCode, generateStubs, generateRpc)
+                            CreateCode(schema, output_path,
+                                       generateCode, generateStubs, generateRpc)
                         if generateDocs:
-                            title = schema["info"]["title"] if "title" in schema else schema["info"]["class"] if "class" in schema else os.path.basename(output_path)
-                            CreateDocument(schema, os.path.join(os.path.dirname(output_path), title.replace(" ","")))
+                            title = schema["info"]["title"] if "title" in schema else schema["info"]["class"] if "class" in schema else os.path.basename(
+                                output_path)
+                            CreateDocument(schema, os.path.join(
+                                os.path.dirname(output_path), title.replace(" ", "")))
             except JsonParseError as err:
                 trace.Error(str(err))
             except RuntimeError as err:
@@ -2198,6 +2520,7 @@ if __name__ == "__main__":
                 trace.Error(str(err))
             except ValueError as err:
                 trace.Error(str(err))
-        print "\nJsonGenerator: All done. %s error%s." % (trace.errors if trace.errors else "No", "" if trace.errors == 1 else "s")
+        print("\nJsonGenerator: All done. {} error{}.".format(
+            trace.errors if trace.errors else 'No', '' if trace.errors == 1 else 's'))
         if trace.errors:
             sys.exit(1)

--- a/Tools/JsonGenerator/JsonGenerator.py
+++ b/Tools/JsonGenerator/JsonGenerator.py
@@ -10,8 +10,8 @@ import urllib
 import glob
 from collections import OrderedDict
 
-sys.path.append(os.path.join(os.path.dirname(
-    os.path.abspath(__file__)), os.pardir))
+sys.path.append(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir))
 
 import ProxyStubGenerator.CppParser
 import ProxyStubGenerator.Interface
@@ -22,6 +22,7 @@ INTERFACE_NAMESPACE = "::WPEFramework::Exchange"
 
 
 class Trace:
+
     def __init__(self):
         self.errors = 0
 
@@ -84,9 +85,12 @@ class JsonParseError(RuntimeError):
 
 
 class CppParseError(RuntimeError):
+
     def __init__(self, obj, msg):
-        msg = "%s(%s): %s (see '%s %s')" % (obj.parser_file, obj.parser_line, msg, " ".join(
-            x if isinstance(x, str) else x.name for x in obj.type), obj.name)
+        msg = "%s(%s): %s (see '%s %s')" % (
+            obj.parser_file, obj.parser_line, msg, " ".join(
+                x if isinstance(x, str) else x.name
+                for x in obj.type), obj.name)
         super(CppParseError, self).__init__(msg)
 
 
@@ -107,6 +111,7 @@ def MakeEnum(type):
 
 
 class JsonType():
+
     def __init__(self, name, parent, schema, included=None):
         self.name = name
         self.true_name = name
@@ -120,7 +125,9 @@ class JsonType():
         if "description" in schema:
             self.description = schema["description"]
         # BUG: Due to a bug in JsonRef, need to pick up the description from the original JSON
-        if isinstance(schema, jsonref.JsonRef) and "description" in schema.__reference__:
+        if isinstance(
+                schema,
+                jsonref.JsonRef) and "description" in schema.__reference__:
             self.description = schema.__reference__["description"]
         # do some sanity check on the description text
         if VERIFY:
@@ -128,45 +135,48 @@ class JsonType():
                 trace.Warn("Item '%s' name ends with a whitespace" % self.name)
             if self.description and not isinstance(self, JsonMethod):
                 if self.description.endswith("."):
-                    trace.Warn("Item '%s' description ends with a dot (\"%s\")" % (
-                        self.name, self.description))
-                if self.description.endswith(" "):
                     trace.Warn(
-                        "Item '%s' description ends with a whitespace" % self.name)
-                if not self.description[0].isupper() and self.description[0].isalpha():
-                    trace.Warn("Item '%s' description does not start with a capital letter (\"%s\")" % (
-                        self.name, self.description))
+                        "Item '%s' description ends with a dot (\"%s\")" %
+                        (self.name, self.description))
+                if self.description.endswith(" "):
+                    trace.Warn("Item '%s' description ends with a whitespace" %
+                               self.name)
+                if not self.description[0].isupper(
+                ) and self.description[0].isalpha():
+                    trace.Warn(
+                        "Item '%s' description does not start with a capital letter (\"%s\")"
+                        % (self.name, self.description))
         if "default" in schema:
             self.default = schema["default"]
 
-    def IsDuplicate(self):      # Whether this object is a duplicate of another
+    def IsDuplicate(self):  # Whether this object is a duplicate of another
         return self.duplicate
 
-    def Schema(self):           # Get the original schema
+    def Schema(self):  # Get the original schema
         return self.schema
 
-    def Description(self):      # Item description
+    def Description(self):  # Item description
         return self.description
 
-    def JsonName(self):         # Name as in JSON
+    def JsonName(self):  # Name as in JSON
         return self.name
 
-    def Properties(self):       # Class attributes
+    def Properties(self):  # Class attributes
         return []
 
-    def Objects(self):          # Class aggregate objects
+    def Objects(self):  # Class aggregate objects
         return []
 
-    def CppType(self):          # C++ type of the object (e.g. may be array)
+    def CppType(self):  # C++ type of the object (e.g. may be array)
         return self.CppClass()
 
-    def CppClass(self):         # C++ class type of the object
+    def CppClass(self):  # C++ class type of the object
         raise RuntimeError("can't instantiate %s" % self.name)
 
-    def CppName(self):          # C++ name of the object
+    def CppName(self):  # C++ name of the object
         return self.name[0].upper() + self.name[1:]
 
-    def CppDefValue(self):      # Value to instantiate with in C++
+    def CppDefValue(self):  # Value to instantiate with in C++
         return ""
 
     # Whether a copy constructor would be needed if this type is a member of a class
@@ -178,6 +188,7 @@ class JsonType():
 
 
 class JsonNull(JsonType):
+
     def CppDefValue(self):
         return "nullptr"
 
@@ -196,6 +207,7 @@ class JsonBoolean(JsonType):
 
 
 class JsonNumber(JsonType):
+
     def __init__(self, name, parent, schema):
         JsonType.__init__(self, name, parent, schema)
         self.size = DEFAULT_INT_SIZE
@@ -205,11 +217,13 @@ class JsonNumber(JsonType):
             self.size = schema["size"]
         if "signed" in schema:
             self.signed = schema["signed"]
+
     # def CppDefValue(self):
     #    return "0"
 
     def CppClass(self):
-        return TypePrefix("Dec%sInt%i" % ("S" if self.signed else "U", self.size))
+        return TypePrefix("Dec%sInt%i" %
+                          ("S" if self.signed else "U", self.size))
 
     def CppStdClass(self):
         return "%sint%i_t" % ("" if self.signed else "u", self.size)
@@ -220,6 +234,7 @@ class JsonInteger(JsonNumber):
 
 
 class JsonString(JsonType):
+
     def CppClass(self):
         return TypePrefix("String")
 
@@ -228,6 +243,7 @@ class JsonString(JsonType):
 
 
 class JsonEnum(JsonType):
+
     def __init__(self, name, parent, schema, enumType, included=None):
         JsonType.__init__(self, name, parent, schema, included)
         if enumType != "string":
@@ -237,9 +253,10 @@ class JsonEnum(JsonType):
         self.enumerators = schema["enum"]
         self.values = schema["enumvalues"] if "enumvalues" in schema else []
         if self.values and (len(self.enumerators) != len(self.values)):
-            raise JsonParseError(
-                "Mismatch in enumeration values in enum '%s'" % self.JsonName())
-        self.strongly_typed = schema["enumtyped"] if "enumtyped" in schema else True
+            raise JsonParseError("Mismatch in enumeration values in enum '%s'" %
+                                 self.JsonName())
+        self.strongly_typed = schema[
+            "enumtyped"] if "enumtyped" in schema else True
         self.default = self.CppClass() + "::" + self.CppEnumerators()[0]
         self.duplicate = False
         self.origRef = None
@@ -264,10 +281,11 @@ class JsonEnum(JsonType):
             if "class" in self.schema:
                 # Override class name if "class" property present
                 classname = self.schema["class"].capitalize()
-            elif CLASSNAME_FROM_REF and isinstance(self.schema, jsonref.JsonRef):
+            elif CLASSNAME_FROM_REF and isinstance(self.schema,
+                                                   jsonref.JsonRef):
                 # NOTE: Abuse the ref feature to construct a name for the enum!
-                classname = MakeEnum(self.schema.__reference__[
-                                     "$ref"].rsplit(posixpath.sep, 1)[1].capitalize())
+                classname = MakeEnum(self.schema.__reference__["$ref"].rsplit(
+                    posixpath.sep, 1)[1].capitalize())
             elif isinstance(self.parent, JsonProperty):
                 classname = MakeEnum(self.parent.name.capitalize())
             else:
@@ -275,7 +293,9 @@ class JsonEnum(JsonType):
             return classname
 
     def CppEnumerators(self):
-        return list(map(lambda x: ("E" if x[0].isdigit() else "") + x.upper(), self.enumerators))
+        return list(
+            map(lambda x: ("E" if x[0].isdigit() else "") + x.upper(),
+                self.enumerators))
 
     def CppEnumeratorValues(self):
         return self.values
@@ -300,9 +320,10 @@ class JsonEnum(JsonType):
 
 
 class JsonObject(JsonType):
+
     def __init__(self, name, parent, schema, origName=None, included=None):
-        self.origName = ((parent.JsonName() + ".")
-                         if parent.JsonName() else "") + name
+        self.origName = (
+            (parent.JsonName() + ".") if parent.JsonName() else "") + name
         JsonType.__init__(self, name, parent, schema, included)
         self.properties = []
         self.objects = []
@@ -360,24 +381,28 @@ class JsonObject(JsonType):
             else:
                 if not self.properties:
                     return TypePrefix("Container")
-                elif CLASSNAME_FROM_REF and isinstance(self.schema, jsonref.JsonRef):
+                elif CLASSNAME_FROM_REF and isinstance(self.schema,
+                                                       jsonref.JsonRef):
                     # NOTE: Abuse the ref feature to construct a name for the class!
-                    classname = MakeObject(self.schema.__reference__[
-                                           "$ref"].rsplit(posixpath.sep, 1)[1].capitalize())
+                    classname = MakeObject(
+                        self.schema.__reference__["$ref"].rsplit(
+                            posixpath.sep, 1)[1].capitalize())
                 else:
                     # Make the name out of properties, but not for params/result types
-                    if len(self.Properties()) == 1 and not isinstance(self.parent, JsonMethod):
+                    if len(self.Properties()) == 1 and not isinstance(
+                            self.parent, JsonMethod):
                         classname = MakeObject(self.Properties()[0].CppName())
                     elif isinstance(self.parent, JsonProperty):
                         classname = MakeObject(self.parent.CppName())
-                    elif self.parent.parent and isinstance(self.parent.parent, JsonProperty):
+                    elif self.parent.parent and isinstance(
+                            self.parent.parent, JsonProperty):
                         classname = MakeObject(self.parent.parent.CppName())
                     else:
                         classname = MakeObject(self.CppName())
             # For common classes append special suffix
             if self.RefCount() > 1:
-                classname = classname.replace(
-                    OBJECT_SUFFIX, COMMON_OBJECT_SUFFIX)
+                classname = classname.replace(OBJECT_SUFFIX,
+                                              COMMON_OBJECT_SUFFIX)
             return classname
 
     def JsonName(self):
@@ -395,9 +420,11 @@ class JsonObject(JsonType):
     def NeedsCopyCtor(self):
         # Check if a copy constructory is needed by scanning all duplicate classes
         filteredClasses = filter(
-            lambda obj: obj.parent.NeedsCopyCtor() if self != obj else False, self.refs)
+            lambda obj: obj.parent.NeedsCopyCtor()
+            if self != obj else False, self.refs)
         foundInDuplicate = next(filteredClasses, None)
-        return ALWAYS_COPYCTOR or self.parent.NeedsCopyCtor() or foundInDuplicate is not None
+        return ALWAYS_COPYCTOR or self.parent.NeedsCopyCtor(
+        ) or foundInDuplicate is not None
 
     def AddRef(self, obj):
         self.refs.append(obj)
@@ -416,12 +443,13 @@ class JsonObject(JsonType):
 
 
 class JsonArray(JsonType):
+
     def __init__(self, name, parent, schema, origName=None, included=None):
         JsonType.__init__(self, name, parent, schema, included)
         self.items = None
         if "items" in schema:
-            self.items = JsonItem(
-                name, self, schema["items"], origName, included)
+            self.items = JsonItem(name, self, schema["items"], origName,
+                                  included)
         else:
             raise JsonParseError("no items in array '%s'" % name)
 
@@ -441,6 +469,7 @@ class JsonArray(JsonType):
 
     def Items(self):
         return self.items
+
     # Delegate all other methods to the underlying type
 
     def CppClass(self):
@@ -466,6 +495,7 @@ class JsonArray(JsonType):
 
 
 class JsonMethod(JsonObject):
+
     def __init__(self, name, parent, schema, included=None):
         objName = name.rsplit(".", 1)[1] if "." in name else name
         # Mimic a JSON object to fit rest of the parsing...
@@ -473,12 +503,13 @@ class JsonMethod(JsonObject):
         newschema = {"type": "object"}
         props = OrderedDict()
         props["params"] = schema["params"] if "params" in schema else {
-            "type": "null"}
+            "type": "null"
+        }
         props["result"] = schema["result"] if "result" in schema else {
-            "type": "null"}
+            "type": "null"
+        }
         newschema["properties"] = props
-        JsonObject.__init__(self, objName, parent,
-                            newschema, included=included)
+        JsonObject.__init__(self, objName, parent, newschema, included=included)
         self.summary = None
         self.tags = []
         if "summary" in schema:
@@ -497,10 +528,12 @@ class JsonMethod(JsonObject):
 
 
 class JsonNotification(JsonMethod):
+
     def __init__(self, name, parent, schema, included=None):
         JsonMethod.__init__(self, name, parent, schema, included)
         self.sendif = "id" in schema
-        self.statuslistener = schema["statuslistener"] if "statuslistener" in schema else False
+        self.statuslistener = schema[
+            "statuslistener"] if "statuslistener" in schema else False
 
     def HasSendif(self):
         return self.sendif
@@ -513,6 +546,7 @@ class JsonNotification(JsonMethod):
 
 
 class JsonProperty(JsonMethod):
+
     def __init__(self, name, parent, schema, included=None):
         JsonMethod.__init__(self, name, parent, schema, included)
         self.readonly = "readonly" in schema and schema["readonly"] == True
@@ -527,6 +561,7 @@ class JsonProperty(JsonMethod):
 
 
 class JsonRpcSchema(JsonType):
+
     def __init__(self, name, schema):
         JsonType.__init__(self, name, None, schema)
         self.info = None
@@ -556,8 +591,8 @@ class JsonRpcSchema(JsonType):
                         self.methods.append(newMethod)
                 if "events" in s:
                     for name, method in s["events"].items():
-                        newMethod = JsonNotification(
-                            name, self, method, include)
+                        newMethod = JsonNotification(name, self, method,
+                                                     include)
                         self.methods.append(newMethod)
 
         method_list = list(map(lambda x: x.name, self.methods))
@@ -572,12 +607,13 @@ class JsonRpcSchema(JsonType):
                         newMethod = ctor(name, self, method)
                         self.methods.append(newMethod)
 
-        __AddMethods("methods", schema, lambda name, obj,
-                     method: JsonMethod(name, obj, method))
-        __AddMethods("properties", schema, lambda name, obj,
-                     method: JsonProperty(name, obj, method))
-        __AddMethods("events", schema, lambda name, obj,
-                     method: JsonNotification(name, obj, method))
+        __AddMethods("methods", schema,
+                     lambda name, obj, method: JsonMethod(name, obj, method))
+        __AddMethods("properties", schema,
+                     lambda name, obj, method: JsonProperty(name, obj, method))
+        __AddMethods(
+            "events", schema,
+            lambda name, obj, method: JsonNotification(name, obj, method))
 
         if not self.methods:
             raise JsonParseError(
@@ -625,7 +661,9 @@ def JsonItem(name, parent, schema, origName=None, included=None):
 
 
 def LoadSchema(file, include_path, cpp_include_path):
+
     def PreprocessJson(file, string, include_path=None, cpp_include_path=None):
+
         def __Tokenize(contents):
             # Tokenize the JSON first to be able to preprocess it easier
             formula = (
@@ -638,25 +676,30 @@ def LoadSchema(file, include_path, cpp_include_path):
                 # singe quotes
                 r"|('(?:[^\\']|\\.)*')"
                 # single-char operators
-                r"|([~,:;?=^/*-\+&<>\{\}\(\)\[\]])"
-            )
-            tokens = [s.strip() for s in re.split(
-                formula, contents, flags=re.MULTILINE) if s]
+                r"|([~,:;?=^/*-\+&<>\{\}\(\)\[\]])")
+            tokens = [
+                s.strip()
+                for s in re.split(formula, contents, flags=re.MULTILINE) if s
+            ]
             # Remove comments from the JSON
-            tokens = [s for s in tokens if (
-                s and (s[:2] != '/*' and s[:2] != '//'))]
+            tokens = [
+                s for s in tokens if (s and (s[:2] != '/*' and s[:2] != '//'))
+            ]
             return tokens
+
         path = os.path.abspath(os.path.dirname(file))
         tokens = __Tokenize(string)
         # BUG?: jsonref (urllib) needs file:// and absolute path to a ref'd file
         for c, t in enumerate(tokens):
-            if t == '"$ref"' and tokens[c + 1] == ":" and tokens[c + 2][:2] != '"#':
+            if t == '"$ref"' and tokens[c +
+                                        1] == ":" and tokens[c + 2][:2] != '"#':
                 ref_file = tokens[c + 2].strip('"')
-                ref_tok = ref_file.split("#", 1) if "#" in ref_file else [
-                    ref_file, ""]
+                ref_tok = ref_file.split(
+                    "#", 1) if "#" in ref_file else [ref_file, ""]
                 if "{interfacedir}/" in ref_file:
                     ref_tok[0] = ref_tok[0].replace(
-                        "{interfacedir}/", (include_path + os.sep) if include_path else "")
+                        "{interfacedir}/",
+                        (include_path + os.sep) if include_path else "")
                     if not include_path:
                         ref_tok[0] = os.path.join(path, ref_tok[0])
                 else:
@@ -664,45 +707,52 @@ def LoadSchema(file, include_path, cpp_include_path):
                         ref_tok[0] = os.path.join(path, ref_tok[0])
                 if not os.path.isfile(ref_tok[0]):
                     raise RuntimeError("$ref file '%s' not found" % ref_tok[0])
-                ref_file = '"file:%s#%s"' % (
-                    urllib.request.pathname2url(ref_tok[0]), ref_tok[1])
+                ref_file = '"file:%s#%s"' % (urllib.request.pathname2url(
+                    ref_tok[0]), ref_tok[1])
                 tokens[c + 2] = ref_file
-            elif t == '"$cppref"' and tokens[c + 1] == ":" and tokens[c + 2][:2] != '"#':
+            elif t == '"$cppref"' and tokens[
+                    c + 1] == ":" and tokens[c + 2][:2] != '"#':
                 ref_file = tokens[c + 2].strip('"')
-                ref_tok = ref_file.split("#", 1) if "#" in ref_file else [
-                    ref_file, ""]
+                ref_tok = ref_file.split(
+                    "#", 1) if "#" in ref_file else [ref_file, ""]
                 if "{cppinterfacedir}/" in ref_file:
                     ref_tok[0] = ref_tok[0].replace(
-                        "{cppinterfacedir}/", (cpp_include_path + os.sep) if cpp_include_path else "")
+                        "{cppinterfacedir}/",
+                        (cpp_include_path + os.sep) if cpp_include_path else "")
                     if not cpp_include_path:
                         ref_tok[0] = os.path.join(path, ref_tok[0])
                 else:
                     if os.path.isfile(os.path.join(path, ref_tok[0])):
                         ref_tok[0] = os.path.join(path, ref_tok[0])
                 if not os.path.isfile(ref_tok[0]):
-                    raise RuntimeError(
-                        "$cppref file '%s' not found" % ref_tok[0])
+                    raise RuntimeError("$cppref file '%s' not found" %
+                                       ref_tok[0])
                 cppif = LoadInterface(ref_tok[0])
                 if cppif:
                     tokens[c] = json.dumps(cppif[0])[1:-1]
                     tokens[c + 1] = ""
                     tokens[c + 2] = ""
                 else:
-                    raise RuntimeError(
-                        "failed to parse C++ header '%s'" % ref_tok[0])
+                    raise RuntimeError("failed to parse C++ header '%s'" %
+                                       ref_tok[0])
         # Return back the preprocessed JSON as a string
         return " ".join(tokens)
+
     with open(file, "r") as json_file:
-        jsonPre = PreprocessJson(
-            file, json_file.read(), include_path, cpp_include_path)
+        jsonPre = PreprocessJson(file, json_file.read(), include_path,
+                                 cpp_include_path)
         return jsonref.loads(jsonPre, object_pairs_hook=OrderedDict)
 
 
 def LoadInterface(file):
-    tree = ProxyStubGenerator.CppParser.ParseFiles([os.path.join(os.path.dirname(
-        os.path.realpath(__file__)), posixpath.normpath(DEFAULT_DEFINITIONS_FILE)), file])
-    interfaces = [i for i in ProxyStubGenerator.Interface.FindInterfaceClasses(
-        tree, INTERFACE_NAMESPACE, file) if i.obj.is_json]
+    tree = ProxyStubGenerator.CppParser.ParseFiles([
+        os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                     posixpath.normpath(DEFAULT_DEFINITIONS_FILE)), file
+    ])
+    interfaces = [
+        i for i in ProxyStubGenerator.Interface.FindInterfaceClasses(
+            tree, INTERFACE_NAMESPACE, file) if i.obj.is_json
+    ]
 
     def Build(face):
         schema = OrderedDict()
@@ -715,7 +765,8 @@ def LoadInterface(file):
         schema["dorpc"] = True
 
         info = dict()
-        info["class"] = face.obj.name[1:] if face.obj.name[0] == "I" else face.obj.name
+        info["class"] = face.obj.name[1:] if face.obj.name[
+            0] == "I" else face.obj.name
         info["title"] = info["class"] + " API"
         info["description"] = info["class"] + " JSON-RPC interface"
         schema["info"] = info
@@ -727,6 +778,7 @@ def LoadInterface(file):
         event_interfaces = set()
 
         for method in face.obj.methods:
+
             def ConvertType(var):
                 cppType = var.type
                 if "string" in cppType or "std::string" in cppType:
@@ -765,24 +817,29 @@ def LoadInterface(file):
                         "(e.g.") if "(e.g" in var.brief else None
                     properties["description"] = var.brief[0:egidx].strip()
                     if egidx and ")" in var.brief[egidx + 1:]:
-                        properties["example"] = var.brief[egidx +
-                                                          5:var.brief.index(")")].strip()
+                        properties["example"] = var.brief[egidx + 5:var.brief.
+                                                          index(")")].strip()
                 return properties
 
             def EventParameters(vars):
                 events = []
                 for var in vars:
+
                     def ResolveTypedef(resolved, events, type):
                         for t in type:
-                            if isinstance(t, ProxyStubGenerator.CppParser.Typedef):
+                            if isinstance(t,
+                                          ProxyStubGenerator.CppParser.Typedef):
                                 if t.is_event:
                                     events.append(t)
                                 ResolveTypedef(resolved, events, t.type)
                             else:
-                                if isinstance(t, ProxyStubGenerator.CppParser.Class) and t.is_event:
+                                if isinstance(
+                                        t, ProxyStubGenerator.CppParser.Class
+                                ) and t.is_event:
                                     events.append(t)
                             resolved.append(t)
                         return events
+
                     resolved = []
                     events = ResolveTypedef(resolved, events, var.type)
                 return events
@@ -793,9 +850,12 @@ def LoadInterface(file):
                 required = []
                 for var in vars:
                     if var.input or not var.output:
-                        if (var.type[-1] == "&" or var.type[-1] == "*") and var.type[0] != "const" and not var.input:
+                        if (var.type[-1] == "&" or var.type[-1] == "*"
+                            ) and var.type[0] != "const" and not var.input:
                             raise CppParseError(
-                                var, "non-const pointer/reference parameter requires in/out tag")
+                                var,
+                                "non-const pointer/reference parameter requires in/out tag"
+                            )
                         var_name = var.name.lower()
                         properties[var_name] = ConvertParameter(var)
                         required.append(var_name)
@@ -822,7 +882,9 @@ def LoadInterface(file):
                     if var.output:
                         if var.type[-1] != "&" and var.type[-1] != "&":
                             raise CppParseError(
-                                var, "parameter marked with @out tag must be either reference or pointer")
+                                var,
+                                "parameter marked with @out tag must be either reference or pointer"
+                            )
                         var_name = var.name.lower()
                         properties[var_name] = ConvertParameter(var)
                         required.append(var_name)
@@ -841,13 +903,16 @@ def LoadInterface(file):
 
             event_params = EventParameters(method.vars)
             for e in event_params:
+
                 def ResolveTypedef(type):
                     if isinstance(type, ProxyStubGenerator.CppParser.Typedef):
                         return ResolveTypedef(type.type[0])
                     else:
                         return type
-                event_interfaces.add(ProxyStubGenerator.Interface.Interface(
-                    ResolveTypedef(e), 0, file))
+
+                event_interfaces.add(
+                    ProxyStubGenerator.Interface.Interface(
+                        ResolveTypedef(e), 0, file))
 
             obj = None
 
@@ -861,7 +926,9 @@ def LoadInterface(file):
                     if "const" in method.qualifiers:
                         if "const" in method.vars[0].type:
                             raise CppParseError(
-                                method.vars[0], "property getter method must not use const parameter")
+                                method.vars[0],
+                                "property getter method must not use const parameter"
+                            )
                         else:
                             if "writeonly" in obj:
                                 del obj["writeonly"]
@@ -872,7 +939,9 @@ def LoadInterface(file):
                     else:
                         if "const" not in method.vars[0].type:
                             raise CppParseError(
-                                method.vars[0], "property setter method must use a const parameter")
+                                method.vars[0],
+                                "property setter method must use a const parameter"
+                            )
                         else:
                             if "readonly" in obj:
                                 del obj["readonly"]
@@ -925,7 +994,8 @@ def LoadInterface(file):
             schema["events"] = events
 
         if DUMP_JSON:
-            print("\n// JSON interface for {} -----------".format(face.obj.name))
+            print("\n// JSON interface for {} -----------".format(
+                face.obj.name))
             print(json.dumps(schema, indent=2))
             print("// ----------------\n")
         return schema
@@ -960,12 +1030,15 @@ def SortByDependency(objects):
     sortedObjects = []
     # This will order objects by their relations
     for obj in sorted(objects, key=lambda x: x.CppClass(), reverse=False):
-        found = filter(lambda sortedObj: obj.CppClass() in map(
-            lambda x: x.CppClass(), sortedObj.Objects()), sortedObjects)
+        found = filter(
+            lambda sortedObj: obj.CppClass() in map(lambda x: x.CppClass(),
+                                                    sortedObj.Objects()),
+            sortedObjects)
         try:
             index = min(map(lambda x: sortedObjects.index(x), found))
-            movelist = filter(lambda x: x.CppClass() in map(
-                lambda x: x.CppClass(), sortedObjects), obj.Objects())
+            movelist = filter(
+                lambda x: x.CppClass() in map(lambda x: x.CppClass(),
+                                              sortedObjects), obj.Objects())
             sortedObjects.insert(index, obj)
             for m in movelist:
                 if m in sortedObjects:
@@ -985,11 +1058,13 @@ def IsInRef(obj):
 
 
 class ObjectTracker:
+
     def __init__(self):
         self.objects = []
         self.Reset()
 
     def Add(self, newObj):
+
         def __Compare(lhs, rhs):
             # NOTE: Two objects are considered identical if they have the same property names and types only!
             for name, prop in lhs.items():
@@ -1015,15 +1090,18 @@ class ObjectTracker:
                     else:
                         return False
             return True
-        if "properties" in newObj.Schema() and not isinstance(newObj, JsonMethod):
+
+        if "properties" in newObj.Schema() and not isinstance(
+                newObj, JsonMethod):
             self.objects.append(newObj)
             is_ref = IsInRef(newObj)
             props = newObj.Schema()["properties"]
             for obj in self.Objects()[:-1]:
                 if __Compare(obj.Schema()["properties"], props):
                     if not is_ref or not IsInRef(obj):
-                        trace.Warn("Duplicate object '%s' (same as '%s') - consider using $ref" %
-                                   (newObj.OrigName(), obj.OrigName()))
+                        trace.Warn(
+                            "Duplicate object '%s' (same as '%s') - consider using $ref"
+                            % (newObj.OrigName(), obj.OrigName()))
                     return obj
             return None
 
@@ -1034,16 +1112,19 @@ class ObjectTracker:
         self.objects = []
 
     def CommonObjects(self):
-        return SortByDependency(filter(lambda obj: obj.RefCount() > 1, self.Objects()))
+        return SortByDependency(
+            filter(lambda obj: obj.RefCount() > 1, self.Objects()))
 
 
 class EnumTracker(ObjectTracker):
+
     def __IsTopmost(self, obj):
         while isinstance(obj.parent, JsonArray):
             obj = obj.parent
         return isinstance(obj.parent, JsonMethod)
 
     def Add(self, newObj):
+
         def __Compare(lhs, rhs):
             # NOTE: Two enums are considered identical if they have the same enumeration names and types
             if (lhs["enum"] == rhs["enum"]) and (lhs["type"] == rhs["type"]):
@@ -1057,19 +1138,24 @@ class EnumTracker(ObjectTracker):
                 return True
             else:
                 return False
+
         if "enum" in newObj.Schema() and not isinstance(newObj, JsonMethod):
             self.objects.append(newObj)
             is_ref = IsInRef(newObj)
             for obj in self.Objects()[:-1]:
                 if __Compare(obj.Schema(), newObj.Schema()):
                     if not is_ref or not IsInRef(obj):
-                        trace.Warn("Duplicate enums '%s' (same as '%s') - consider using $ref" %
-                                   (newObj.OrigName(), obj.OrigName()))
+                        trace.Warn(
+                            "Duplicate enums '%s' (same as '%s') - consider using $ref"
+                            % (newObj.OrigName(), obj.OrigName()))
                     return obj
             return None
 
     def CommonObjects(self):
-        return SortByDependency(filter(lambda obj: obj.RefCount() > 1 or self.__IsTopmost(obj), self.Objects()))
+        return SortByDependency(
+            filter(lambda obj: obj.RefCount() > 1 or self.__IsTopmost(obj),
+                   self.Objects()))
+
 
 #
 # THE EMITTER
@@ -1077,6 +1163,7 @@ class EnumTracker(ObjectTracker):
 
 
 class Emitter():
+
     def __init__(self, file, indentSize):
         self.indent_size = indentSize
         self.indent = 0
@@ -1097,6 +1184,7 @@ class Emitter():
         else:
             self.indent = 0
 
+
 #
 # JSON OBJECT GENERATION
 #
@@ -1109,7 +1197,8 @@ def GetNamespace(root, obj, full=True):
             return namespace
         fullname = ""
         e = obj
-        while e.parent and not isinstance(e, JsonMethod) and (not e.IsDuplicate() or e.RefCount() > 1):
+        while e.parent and not isinstance(
+                e, JsonMethod) and (not e.IsDuplicate() or e.RefCount() > 1):
             if not isinstance(e, (JsonEnum, JsonArray)):
                 fullname = e.CppClass() + "::" + fullname
             if e.RefCount() > 1:
@@ -1122,6 +1211,7 @@ def GetNamespace(root, obj, full=True):
 
 
 def EmitEnumRegs(root, emit, header_file):
+
     def EmitEnumRegistration(root, enum, full=True):
         fullname = (GetNamespace(root, enum) if full else "%s::%s::" %
                     (DATA_NAMESPACE, root.CppClass())) + enum.CppClass()
@@ -1162,8 +1252,11 @@ def EmitEvent(emit, root, event, static=False):
         emit.Line("// Event: %s" % event.JsonName())
     params = event.Properties()[0].CppType()
     par = "const string& id, " if event.HasSendif() else ""
-    par = par + ", ".join(map(lambda x: "const " + GetNamespace(root, x, False) +
-                              x.CppStdClass() + "& " + x.JsonName(), event.Properties()[0].Properties()))
+    par = par + ", ".join(
+        map(
+            lambda x: "const " + GetNamespace(root, x, False) + x.CppStdClass()
+            + "& " + x.JsonName(),
+            event.Properties()[0].Properties()))
     if not static:
         line = "void %s::%s(%s)" % (root.JsonName(), event.MethodName(), par)
     else:
@@ -1180,17 +1273,19 @@ def EmitEvent(emit, root, event, static=False):
             emit.Line("params.%s = %s;" % (p.CppName(), p.JsonName()))
         emit.Line()
     if event.HasSendif():
-        emit.Line('Notify(_T("%s")%s, [&](const string& designator) -> bool {' % (
-            event.JsonName(), ", params" if params != "void" else ""))
+        emit.Line('Notify(_T("%s")%s, [&](const string& designator) -> bool {' %
+                  (event.JsonName(), ", params" if params != "void" else ""))
         emit.Indent()
         emit.Line(
-            "const string designator_id = designator.substr(0, designator.find('.'));")
+            "const string designator_id = designator.substr(0, designator.find('.'));"
+        )
         emit.Line("return (id == designator_id);")
         emit.Unindent()
         emit.Line("});")
     else:
-        emit.Line('%sNotify(_T("%s")%s);' % ("module." if static else "",
-                                             event.JsonName(), ", params" if params != "void" else ""))
+        emit.Line('%sNotify(_T("%s")%s);' %
+                  ("module." if static else "", event.JsonName(),
+                   ", params" if params != "void" else ""))
     emit.Unindent()
     emit.Line("}")
     emit.Line()
@@ -1218,7 +1313,8 @@ def EmitRpcCode(root, emit, header_file, source_file):
     emit.Indent()
     emit.Line()
     emit.Line(
-        "static void Register(PluginHost::JSONRPC& module, %s* destination)" % face)
+        "static void Register(PluginHost::JSONRPC& module, %s* destination)" %
+        face)
     emit.Line("{")
     emit.Indent()
     emit.Line("ASSERT(destination != nullptr);")
@@ -1233,13 +1329,16 @@ def EmitRpcCode(root, emit, header_file, source_file):
                 params = m.Properties()[0] if not m.readonly else void
                 response = m.Properties()[0] if not m.writeonly else void
                 response.name = "result"
-                emit.Line("// Property: '%s'%s%s%s" % (m.JsonName(), " (r/o)" if m.readonly else (
-                    " (w/o)" if m.writeonly else ""), " - " if m.summary else "", m.summary if m.summary else ""))
+                emit.Line("// Property: '%s'%s%s%s" %
+                          (m.JsonName(), " (r/o)" if m.readonly else
+                           (" (w/o)" if m.writeonly else ""), " - " if m.summary
+                           else "", m.summary if m.summary else ""))
             else:
                 params = m.Properties()[0]
                 response = m.Properties()[1]
-                emit.Line("// Method: '%s'%s%s" % (m.JsonName(),
-                                                   " - " if m.summary else "", m.summary if m.summary else ""))
+                emit.Line("// Method: '%s'%s%s" %
+                          (m.JsonName(), " - " if m.summary else "",
+                           m.summary if m.summary else ""))
             line = 'module.Register<%s,%s>(_T("%s"),' % (
                 params.CppType(), response.CppType(), m.JsonName())
             emit.Line(line)
@@ -1275,7 +1374,8 @@ def EmitRpcCode(root, emit, header_file, source_file):
                     if isinstance(response, JsonObject):
                         for p in params.Properties():
                             if not isinstance(p, (JsonObject, JsonArray)):
-                                line = line + "params.%s.Value(), " % p.CppName()
+                                line = line + "params.%s.Value(), " % p.CppName(
+                                )
                     else:
                         line = line + "params.Value(), "
                 if response.CppType() != "void":
@@ -1412,22 +1512,27 @@ def EmitHelperCode(root, emit, header_file):
         emit.Indent()
         emit.Line("// Copy the code below to %s class definition" %
                   root.JsonName())
-        emit.Line("// Note: The %s class must inherit from PluginHost::JSONRPC%s" %
-                  (root.JsonName(), "SupportsEventStatus" if has_statuslistener else ""))
+        emit.Line(
+            "// Note: The %s class must inherit from PluginHost::JSONRPC%s" %
+            (root.JsonName(),
+             "SupportsEventStatus" if has_statuslistener else ""))
         emit.Line()
         emit.Line("private:")
         emit.Indent()
         emit.Line("void RegisterAll();")
         emit.Line("void UnregisterAll();")
         for method in root.Properties():
-            if not isinstance(method, JsonProperty) and not isinstance(method, JsonNotification):
+            if not isinstance(method, JsonProperty) and not isinstance(
+                    method, JsonNotification):
                 params = __NsName(method.Properties()[0])
                 response = __NsName(method.Properties()[1])
-                line = ("uint32_t %s(%s%s%s);" % (method.MethodName(),
-                                                  ("const " + params +
-                                                   "& params") if params != "void" else "",
-                                                  ", " if params != "void" and response != "void" else "",
-                                                  (response + "& response") if response != "void" else ""))
+                line = (
+                    "uint32_t %s(%s%s%s);" %
+                    (method.MethodName(),
+                     ("const " + params +
+                      "& params") if params != "void" else "",
+                     ", " if params != "void" and response != "void" else "",
+                     (response + "& response") if response != "void" else ""))
                 if method.included_from:
                     line += " // %s" % method.included_from
                 emit.Line(line)
@@ -1435,14 +1540,18 @@ def EmitHelperCode(root, emit, header_file):
         for method in root.Properties():
             if isinstance(method, JsonProperty):
                 if not method.writeonly:
-                    line = "uint32_t %s(%s%s& response) const;" % (method.GetMethodName(
-                    ), "const string& index, " if method.has_index else "", __NsName(method.Properties()[0]))
+                    line = "uint32_t %s(%s%s& response) const;" % (
+                        method.GetMethodName(),
+                        "const string& index, " if method.has_index else "",
+                        __NsName(method.Properties()[0]))
                     if method.included_from:
                         line += " // %s" % method.included_from
                     emit.Line(line)
                 if not method.readonly:
-                    line = "uint32_t %s(%sconst %s& param);" % (method.SetMethodName(
-                    ), "const string& index, " if method.has_index else "", __NsName(method.Properties()[0]))
+                    line = "uint32_t %s(%sconst %s& param);" % (
+                        method.SetMethodName(),
+                        "const string& index, " if method.has_index else "",
+                        __NsName(method.Properties()[0]))
                     if method.included_from:
                         line += " // %s" % method.included_from
                     emit.Line(line)
@@ -1452,10 +1561,14 @@ def EmitHelperCode(root, emit, header_file):
                 params = __NsName(method.Properties()[0])
                 par = ""
                 if params != "void":
-                    par = ", ".join(map(lambda x: "const " + GetNamespace(root, x) + x.CppStdClass(
-                    ) + "& " + x.JsonName(), method.Properties()[0].Properties()))
-                line = ('void %s(%s%s);' % (method.MethodName(),
-                                            "const string& id, " if method.HasSendif() else "", par))
+                    par = ", ".join(
+                        map(
+                            lambda x: "const " + GetNamespace(root, x) + x.
+                            CppStdClass() + "& " + x.JsonName(),
+                            method.Properties()[0].Properties()))
+                line = ('void %s(%s%s);' %
+                        (method.MethodName(), "const string& id, "
+                         if method.HasSendif() else "", par))
                 if method.included_from:
                     line += " // %s" % method.included_from
                 emit.Line(line)
@@ -1484,7 +1597,8 @@ def EmitHelperCode(root, emit, header_file):
         for method in root.Properties():
             if isinstance(method, JsonNotification) and method.StatusListener():
                 emit.Line(
-                    "RegisterEventStatusListener(_T(\"%s\"), [this](const string& client, Status status) {" % method.JsonName())
+                    "RegisterEventStatusListener(_T(\"%s\"), [this](const string& client, Status status) {"
+                    % method.JsonName())
                 emit.Indent()
                 emit.Line(
                     "const string id = client.substr(0, client.find('.'));")
@@ -1493,18 +1607,21 @@ def EmitHelperCode(root, emit, header_file):
                 emit.Line("});")
                 emit.Line()
         for method in root.Properties():
-            if not isinstance(method, JsonNotification) and not isinstance(method, JsonProperty):
-                line = 'Register<%s,%s>(_T("%s"), &%s::%s, this);' % (method.Properties()[0].CppType(
-                ), method.Properties()[1].CppType(), method.JsonName(), root.JsonName(), method.MethodName())
+            if not isinstance(method, JsonNotification) and not isinstance(
+                    method, JsonProperty):
+                line = 'Register<%s,%s>(_T("%s"), &%s::%s, this);' % (
+                    method.Properties()[0].CppType(),
+                    method.Properties()[1].CppType(), method.JsonName(),
+                    root.JsonName(), method.MethodName())
                 if method.included_from:
                     line += " /* %s */" % method.included_from
                 emit.Line(line)
         for method in root.Properties():
             if isinstance(method, JsonProperty):
-                line = 'Property<%s>(_T("%s")' % (method.Properties()[
-                    0].CppType(), method.JsonName())
-                line += ", &%s::%s" % (root.JsonName(), method.GetMethodName()
-                                       ) if not method.writeonly else ", nullptr"
+                line = 'Property<%s>(_T("%s")' % (
+                    method.Properties()[0].CppType(), method.JsonName())
+                line += ", &%s::%s" % (root.JsonName(), method.GetMethodName(
+                )) if not method.writeonly else ", nullptr"
                 line += ", &%s::%s" % (root.JsonName(), method.SetMethodName()
                                        ) if not method.readonly else ", nullptr"
                 line += ', this);'
@@ -1518,7 +1635,8 @@ def EmitHelperCode(root, emit, header_file):
         emit.Line("{")
         emit.Indent()
         for method in reversed(root.Properties()):
-            if not isinstance(method, JsonNotification) and not isinstance(method, JsonProperty):
+            if not isinstance(method, JsonNotification) and not isinstance(
+                    method, JsonProperty):
                 emit.Line('Unregister(_T("%s"));' % method.JsonName())
         for method in reversed(root.Properties()):
             if isinstance(method, JsonProperty):
@@ -1538,25 +1656,30 @@ def EmitHelperCode(root, emit, header_file):
         emit.Line("//")
         emit.Line()
         for method in root.Properties():
-            if not isinstance(method, JsonNotification) and not isinstance(method, JsonProperty):
+            if not isinstance(method, JsonNotification) and not isinstance(
+                    method, JsonProperty):
                 print("Emitting method '{}'".format(method.JsonName()))
                 params = method.Properties()[0].CppType()
                 if method.Summary():
-                    emit.Line("// Method: %s - %s" %
-                              (method.JsonName(), method.Summary().split(".", 1)[0]))
+                    emit.Line(
+                        "// Method: %s - %s" %
+                        (method.JsonName(), method.Summary().split(".", 1)[0]))
                 emit.Line("// Return codes:")
                 emit.Line("//  - ERROR_NONE: Success")
                 for e in method.Errors():
                     description = e["description"] if "description" in e else ""
-                    if isinstance(e, jsonref.JsonRef) and "description" in e.__reference__:
+                    if isinstance(e, jsonref.JsonRef
+                                  ) and "description" in e.__reference__:
                         description = e.__reference__["description"]
                     emit.Line("//  - %s: %s" % (e["message"], description))
                 response = method.Properties()[1].CppType()
-                line = ("uint32_t %s::%s(%s%s%s)" % (root.JsonName(), method.MethodName(),
-                                                     ("const " + params +
-                                                      "& params") if params != "void" else "",
-                                                     ", " if params != "void" and response != "void" else "",
-                                                     (response + "& response") if response != "void" else ""))
+                line = (
+                    "uint32_t %s::%s(%s%s%s)" %
+                    (root.JsonName(), method.MethodName(),
+                     ("const " + params +
+                      "& params") if params != "void" else "",
+                     ", " if params != "void" and response != "void" else "",
+                     (response + "& response") if response != "void" else ""))
                 if method.included_from:
                     line += " /* %s */" % method.included_from
                 emit.Line(line)
@@ -1566,8 +1689,9 @@ def EmitHelperCode(root, emit, header_file):
                 if params != "void":
                     for p in method.Properties()[0].Properties():
                         if not isinstance(p, (JsonObject, JsonArray)):
-                            emit.Line("const %s& %s = params.%s.Value();" % (
-                                p.CppStdClass(), p.JsonName(), p.CppName()))
+                            emit.Line(
+                                "const %s& %s = params.%s.Value();" %
+                                (p.CppStdClass(), p.JsonName(), p.CppName()))
                         else:
                             emit.Line("// params.%s ..." % p.CppName())
                 emit.Line()
@@ -1584,20 +1708,27 @@ def EmitHelperCode(root, emit, header_file):
 
         for method in root.Properties():
             if isinstance(method, JsonProperty):
+
                 def EmitPropertyFc(method, name, getter):
                     params = method.Properties()[0].CppType()
                     if method.Summary():
                         emit.Line("// Property: %s - %s" %
-                                  (method.JsonName(), method.Summary().split(".", 1)[0]))
+                                  (method.JsonName(), method.Summary().split(
+                                      ".", 1)[0]))
                     emit.Line("// Return codes:")
                     emit.Line("//  - ERROR_NONE: Success")
                     for e in method.Errors():
-                        description = e["description"] if "description" in e else ""
-                        if isinstance(e, jsonref.JsonRef) and "description" in e.__reference__:
+                        description = e[
+                            "description"] if "description" in e else ""
+                        if isinstance(e, jsonref.JsonRef
+                                      ) and "description" in e.__reference__:
                             description = e.__reference__["description"]
                         emit.Line("//  - %s: %s" % (e["message"], description))
-                    line = "uint32_t %s::%s(%s%s%s& %s)%s" % (root.JsonName(), name, "const string& index, " if method.has_index else "",
-                                                              "const " if not getter else "", params, "response" if getter else "param", " const" if getter else "")
+                    line = "uint32_t %s::%s(%s%s%s& %s)%s" % (
+                        root.JsonName(), name,
+                        "const string& index, " if method.has_index else "",
+                        "const " if not getter else "", params, "response"
+                        if getter else "param", " const" if getter else "")
                     if method.included_from:
                         line += " /* %s */" % method.included_from
                     emit.Line(line)
@@ -1615,6 +1746,7 @@ def EmitHelperCode(root, emit, header_file):
                     emit.Unindent()
                     emit.Line("}")
                     emit.Line()
+
                 propType = ' (write-only)' if method.writeonly else (
                     ' (read-only)' if method.readonly else '')
                 print("Emitting property '{}' {}".format(
@@ -1653,17 +1785,21 @@ def EmitObjects(root, emit, emitCommon=False):
             root = root.parent
         if enum.Description():
             emit.Line("// " + enum.Description())
-        emit.Line("enum%s %s {" % (
-            " class" if enum.IsStronglyTyped() else "", enum.CppClass()))
+        emit.Line("enum%s %s {" %
+                  (" class" if enum.IsStronglyTyped() else "", enum.CppClass()))
         emit.Indent()
         for c, item in enumerate(enum.CppEnumerators()):
-            emit.Line("%s%s%s" % (item.upper(), (" = " + str(enum.CppEnumeratorValues()
-                                                             [c])) if enum.CppEnumeratorValues() else "", "," if not c == len(enum.CppEnumerators()) - 1 else ""))
+            emit.Line("%s%s%s" %
+                      (item.upper(),
+                       (" = " + str(enum.CppEnumeratorValues()[c]))
+                       if enum.CppEnumeratorValues() else "",
+                       "," if not c == len(enum.CppEnumerators()) - 1 else ""))
         emit.Unindent()
         emit.Line("};")
         emit.Line()
 
     def EmitClass(jsonObj, allowDup=False):
+
         def EmitInit(jsonObject):
             for prop in jsonObj.Properties():
                 emit.Line("Add(_T(\"%s\"), &%s);" %
@@ -1682,8 +1818,7 @@ def EmitObjects(root, emit, emitCommon=False):
                     emit.Line(", %s(other.%s)" %
                               (prop.CppName(), prop.CppName()))
                 elif prop.CppDefValue() != '""' and prop.CppDefValue() != "":
-                    emit.Line(", %s(%s)" %
-                              (prop.CppName(), prop.CppDefValue()))
+                    emit.Line(", %s(%s)" % (prop.CppName(), prop.CppDefValue()))
             emit.Unindent()
             emit.Line("{")
             emit.Indent()
@@ -1702,8 +1837,8 @@ def EmitObjects(root, emit, emitCommon=False):
         if not isinstance(jsonObj, (JsonRpcSchema, JsonMethod)):
             print("Emitting class '{}' (source: '{}')".format(
                 jsonObj.CppClass(), jsonObj.OrigName()))
-            emit.Line("class %s : public %s {" % (
-                jsonObj.CppClass(), TypePrefix("Container")))
+            emit.Line("class %s : public %s {" %
+                      (jsonObj.CppClass(), TypePrefix("Container")))
             emit.Line("public:")
             if jsonObj.Enums():
                 for enum in jsonObj.Enums():
@@ -1735,8 +1870,7 @@ def EmitObjects(root, emit, emitCommon=False):
                 emit.Line("{")
                 emit.Indent()
                 for prop in jsonObj.Properties():
-                    emit.Line("%s = rhs.%s;" %
-                              (prop.CppName(), prop.CppName()))
+                    emit.Line("%s = rhs.%s;" % (prop.CppName(), prop.CppName()))
                 emit.Line("return (*this);")
                 emit.Unindent()
                 emit.Line("}")
@@ -1831,12 +1965,14 @@ def EmitObjects(root, emit, emitCommon=False):
 
 def CreateCode(schema, path, generateClasses, generateStubs, generateRpc):
     directory = os.path.dirname(path)
-    filename = (schema["info"]["class"]) if "info" in schema and "class" in schema["info"] else os.path.basename(
+    filename = (
+        schema["info"]["class"]
+    ) if "info" in schema and "class" in schema["info"] else os.path.basename(
         path.replace("Plugin", "").replace(".json", "").replace(".h", ""))
     rpcObj = ParseJsonRpcSchema(schema)
     if rpcObj:
-        header_file = os.path.join(
-            directory, DATA_NAMESPACE + "_" + filename + ".h")
+        header_file = os.path.join(directory,
+                                   DATA_NAMESPACE + "_" + filename + ".h")
         enum_file = os.path.join(directory, "JsonEnum_" + filename + ".cpp")
 
         if generateClasses:
@@ -1850,15 +1986,16 @@ def CreateCode(schema, path, generateClasses, generateStubs, generateRpc):
                              os.path.basename(path))
                 emitter.Line()
                 emitter.Line(
-                    "// Note: This code is inherently not thread safe. If required, proper synchronisation must be added.")
+                    "// Note: This code is inherently not thread safe. If required, proper synchronisation must be added."
+                )
                 emitter.Line()
                 emitted = EmitObjects(rpcObj, emitter, True)
                 if emitted:
-                    trace.Success(
-                        "JSON data classes generated in '%s'." % output_file.name)
+                    trace.Success("JSON data classes generated in '%s'." %
+                                  output_file.name)
                 else:
-                    trace.Success(
-                        "No JSON data classes generated for '%s'." % filename)
+                    trace.Success("No JSON data classes generated for '%s'." %
+                                  filename)
             if not emitted and not KEEP_EMPTY:
                 try:
                     os.remove(header_file)
@@ -1875,11 +2012,12 @@ def CreateCode(schema, path, generateClasses, generateStubs, generateRpc):
                 emitter.Line()
                 emitted = EmitEnumRegs(rpcObj, emitter, filename)
                 if emitted:
-                    trace.Success(
-                        "JSON enumeration code generated in '%s'." % output_file.name)
+                    trace.Success("JSON enumeration code generated in '%s'." %
+                                  output_file.name)
                 else:
                     trace.Success(
-                        "No JSON enumeration code generated for '%s'." % filename)
+                        "No JSON enumeration code generated for '%s'." %
+                        filename)
             if not emitted and not KEEP_EMPTY:
                 try:
                     os.remove(enum_file)
@@ -1887,20 +2025,23 @@ def CreateCode(schema, path, generateClasses, generateStubs, generateRpc):
                     pass
 
         if generateStubs:
-            with open(os.path.join(directory, filename + "JsonRpc.cpp"), "w") as output_file:
+            with open(os.path.join(directory, filename + "JsonRpc.cpp"),
+                      "w") as output_file:
                 emitter = Emitter(output_file, INDENT_SIZE)
                 emitter.Line()
                 EmitHelperCode(rpcObj, emitter, os.path.basename(header_file))
                 trace.Success("JSON-RPC stubs generated in '%s'." %
                               output_file.name)
 
-        if generateRpc and "dorpc" in rpcObj.schema and rpcObj.schema["dorpc"] == True:
-            with open(os.path.join(directory, "J" + filename + ".h"), "w") as output_file:
+        if generateRpc and "dorpc" in rpcObj.schema and rpcObj.schema[
+                "dorpc"] == True:
+            with open(os.path.join(directory, "J" + filename + ".h"),
+                      "w") as output_file:
                 emitter = Emitter(output_file, INDENT_SIZE)
                 emitter.Line()
                 EmitRpcCode(rpcObj, emitter, filename, os.path.basename(path))
-                trace.Success(
-                    "JSON-RPC implementation generated in '%s'." % output_file.name)
+                trace.Success("JSON-RPC implementation generated in '%s'." %
+                              output_file.name)
 
     else:
         trace.Success("No code to generate.")
@@ -1910,9 +2051,10 @@ def CreateCode(schema, path, generateClasses, generateStubs, generateRpc):
 # DOCUMENTATION GENERATION
 #
 
+
 def CreateDocument(schema, path):
-    output_path = os.path.dirname(
-        path) + "/" + os.path.basename(path).replace(".json", "") + ".md"
+    output_path = os.path.dirname(path) + "/" + os.path.basename(path).replace(
+        ".json", "") + ".md"
     with open(output_path, "w") as output_file:
         emit = Emitter(output_file, INDENT_SIZE)
 
@@ -1923,7 +2065,8 @@ def CreateDocument(schema, path):
             return "*%s*" % string
 
         def link(string):
-            return "[%s](#%s)" % (string.split(".", 1)[1].replace("_", " "), string)
+            return "[%s](#%s)" % (string.split(".", 1)[1].replace("_",
+                                                                  " "), string)
 
         def MdBr():
             emit.Line()
@@ -1934,8 +2077,9 @@ def CreateDocument(schema, path):
                           (id + "." + string.replace(" ", "_")))
             if id != "head":
                 string += " <sup>%s</sup>" % id
-            emit.Line("%s %s" % ("#" * level, "*%s*" %
-                                 string if id != "head" else string))
+            emit.Line(
+                "%s %s" %
+                ("#" * level, "*%s*" % string if id != "head" else string))
             MdBr()
 
         def MdBody(string=""):
@@ -1963,43 +2107,58 @@ def CreateDocument(schema, path):
         def ParamTable(name, object):
             MdTableHeader(["Name", "Type", "Description"])
 
-            def __TableObj(name, obj, parentName="", parent=None, prefix="", parentOptional=False):
+            def __TableObj(name,
+                           obj,
+                           parentName="",
+                           parent=None,
+                           prefix="",
+                           parentOptional=False):
                 # determine if the attribute is optional
-                optional = parentOptional or (
-                    obj["optional"] if "optional" in obj else False)
+                optional = parentOptional or (obj["optional"]
+                                              if "optional" in obj else False)
                 if parent and not optional:
                     if parent["type"] == "object":
-                        optional = ("required" not in parent and len(parent["properties"]) > 1) or (
-                            "required" in parent and name not in parent["required"]) or ("required" in parent and len(parent["required"]) == 0)
+                        optional = ("required" not in parent
+                                    and len(parent["properties"]) > 1) or (
+                                        "required" in parent
+                                        and name not in parent["required"]) or (
+                                            "required" in parent
+                                            and len(parent["required"]) == 0)
 
                 # include information about enum values in description
-                enum = ' (must be one of the following: %s)' % (
-                    ", ".join('*{0}*'.format(w) for w in obj["enum"])) if "enum" in obj else ""
+                enum = ' (must be one of the following: %s)' % (", ".join(
+                    '*{0}*'.format(w)
+                    for w in obj["enum"])) if "enum" in obj else ""
                 if parent and prefix and parent["type"] == "object":
                     prefix += "?." if optional else "."
                 prefix += name
-                description = obj["description"] if "description" in obj else obj["summary"] if "summary" in obj else ""
-                if isinstance(obj, jsonref.JsonRef) and "description" in obj.__reference__:
+                description = obj[
+                    "description"] if "description" in obj else obj[
+                        "summary"] if "summary" in obj else ""
+                if isinstance(
+                        obj,
+                        jsonref.JsonRef) and "description" in obj.__reference__:
                     description = obj.__reference__["description"]
                 if name or prefix:
                     if "type" not in obj:
-                        raise RuntimeError(
-                            "missing 'type' for object %s" % (parentName + "/" + name))
-                    row = (("<sup>" + italics("(optional)") + "</sup>" + " ")
-                           if optional else "") + description + enum
+                        raise RuntimeError("missing 'type' for object %s" %
+                                           (parentName + "/" + name))
+                    row = (("<sup>" + italics("(optional)") + "</sup>" +
+                            " ") if optional else "") + description + enum
                     if row.endswith('.'):
                         row = row[:-1]
                     MdRow([prefix, obj["type"], row])
                 if obj["type"] == "object":
-                    if "required" not in obj and name and len(obj["properties"]) > 1:
-                        trace.Warn(
-                            'No "required" field for object "%s"' % name)
+                    if "required" not in obj and name and len(
+                            obj["properties"]) > 1:
+                        trace.Warn('No "required" field for object "%s"' % name)
                     for pname, props in obj["properties"].items():
-                        __TableObj(pname, props, parentName +
-                                   "/" + name, obj, prefix, False)
+                        __TableObj(pname, props, parentName + "/" + name, obj,
+                                   prefix, False)
                 elif obj["type"] == "array":
-                    __TableObj("", obj["items"], parentName + "/" + name,
-                               obj, (prefix + "[#]") if name else "", optional)
+                    __TableObj("", obj["items"], parentName + "/" + name, obj,
+                               (prefix + "[#]") if name else "", optional)
+
             __TableObj(name, object, "")
             MdBr()
 
@@ -2007,22 +2166,30 @@ def CreateDocument(schema, path):
             MdTableHeader(["Code", "Message", "Description"])
             for err in obj:
                 description = err["description"] if "description" in err else ""
-                if isinstance(err, jsonref.JsonRef) and "description" in err.__reference__:
+                if isinstance(
+                        err,
+                        jsonref.JsonRef) and "description" in err.__reference__:
                     description = err.__reference__["description"]
-                MdRow([err["code"] if "code" in err else "",
-                       "```" + err["message"] + "```", description])
+                MdRow([
+                    err["code"] if "code" in err else "",
+                    "```" + err["message"] + "```", description
+                ])
             MdBr()
 
         def PlainTable(obj, columns, ref="ref"):
             MdTableHeader(columns)
             for prop, val in sorted(obj.items()):
-                MdRow(["<a name=\"%s.%s\">%s</a>" % (ref, (prop.split("]", 1)
-                                                           [0][1:]) if "]" in prop else prop, prop), val])
+                MdRow([
+                    "<a name=\"%s.%s\">%s</a>" %
+                    (ref, (prop.split("]", 1)[0][1:]) if "]" in prop else prop,
+                     prop), val
+                ])
             MdBr()
 
         def __ExampleObj(name, obj):
             objType = obj["type"]
-            default = obj["example"] if "example" in obj else obj["default"] if "default" in obj else ""
+            default = obj["example"] if "example" in obj else obj[
+                "default"] if "default" in obj else ""
             if not default and "enum" in obj:
                 default = obj["enum"][0]
             jsonData = '"%s": ' % name if name else ''
@@ -2038,15 +2205,25 @@ def CreateDocument(schema, path):
                 jsonData += str(default if default else (
                     '[ %s ]' % (__ExampleObj("", obj["items"]))))
             elif objType == "object":
-                jsonData += "{ %s }" % ", ".join(list(map(lambda p: __ExampleObj(p, obj["properties"][p]), obj["properties"]))[
-                                                 0:obj["maxProperties"] if "maxProperties" in obj else None])
+                jsonData += "{ %s }" % ", ".join(
+                    list(
+                        map(lambda p: __ExampleObj(p, obj["properties"][p]),
+                            obj["properties"]))
+                    [0:obj["maxProperties"] if "maxProperties" in
+                     obj else None])
             return jsonData
 
-        def MethodDump(method, props, classname, is_notification=False, is_property=False, include=None):
-            method = (method.rsplit(".", 1)[
-                      1] if "." in method else method).lower()
+        def MethodDump(method,
+                       props,
+                       classname,
+                       is_notification=False,
+                       is_property=False,
+                       include=None):
+            method = (method.rsplit(".", 1)[1]
+                      if "." in method else method).lower()
             MdHeader(
-                method, 2, "property" if is_property else "event" if is_notification else "method", include)
+                method, 2, "property" if is_property else
+                "event" if is_notification else "method", include)
             readonly = False
             writeonly = False
             if "summary" in props:
@@ -2069,19 +2246,24 @@ def CreateDocument(schema, path):
                 MdHeader("Description", 3)
                 MdParagraph(props["description"])
             if "events" in props:
-                MdParagraph(
-                    "Also see: " + (", ".join(map(lambda x: link("event." + x), props["events"]))))
+                MdParagraph("Also see: " + (", ".join(
+                    map(lambda x: link("event." + x), props["events"]))))
             if is_property:
                 MdHeader("Value", 3)
                 if not "description" in props["params"]:
                     props["params"]["description"] = props["summary"]
                 ParamTable("(property)", props["params"])
                 if "index" in props:
-                    if "name" not in props["index"] or "example" not in props["index"]:
+                    if "name" not in props["index"] or "example" not in props[
+                            "index"]:
                         raise RuntimeError(
-                            "in %s: index field needs 'name' and 'example' properties" % method)
-                    extra_paragraph = "> The *%s* shall be passed as the index to the property, e.g. *%s.1.%s@%s*.%s" % (props["index"]["name"].lower(
-                    ), classname, method, props["index"]["example"], (" " + props["index"]["description"]) if "description" in props["index"] else "")
+                            "in %s: index field needs 'name' and 'example' properties"
+                            % method)
+                    extra_paragraph = "> The *%s* shall be passed as the index to the property, e.g. *%s.1.%s@%s*.%s" % (
+                        props["index"]["name"].lower(), classname, method,
+                        props["index"]["example"],
+                        (" " + props["index"]["description"])
+                        if "description" in props["index"] else "")
                     if not extra_paragraph.endswith('.'):
                         extra_paragraph += '.'
                     MdParagraph(extra_paragraph)
@@ -2096,11 +2278,14 @@ def CreateDocument(schema, path):
                         MdParagraph("This method takes no parameters.")
                 if is_notification:
                     if "id" in props:
-                        if "name" not in props["id"] or "example" not in props["id"]:
+                        if "name" not in props["id"] or "example" not in props[
+                                "id"]:
                             raise RuntimeError(
-                                "in %s: id field needs 'name' and 'example' properties" % method)
-                        MdParagraph("> The *%s* shall be passed within the designator, e.g. *%s.client.events.1*." % (
-                            props["id"]["name"], props["id"]["example"]))
+                                "in %s: id field needs 'name' and 'example' properties"
+                                % method)
+                        MdParagraph(
+                            "> The *%s* shall be passed within the designator, e.g. *%s.client.events.1*."
+                            % (props["id"]["name"], props["id"]["example"]))
 
             if "result" in props:
                 MdHeader("Result", 3)
@@ -2114,8 +2299,10 @@ def CreateDocument(schema, path):
             if is_notification:
                 method = "client.events.1." + method
             elif is_property:
-                method = "%s.1.%s%s" % (
-                    classname, method, ("@" + props["index"]["example"]) if "index" in props and "example" in props["index"] else "")
+                method = "%s.1.%s%s" % (classname, method,
+                                        ("@" + props["index"]["example"])
+                                        if "index" in props
+                                        and "example" in props["index"] else "")
             else:
                 method = "%s.1.%s" % (classname, method)
             if "id" in props and "example" in props["id"]:
@@ -2126,11 +2313,17 @@ def CreateDocument(schema, path):
                 if not writeonly:
                     MdHeader("Get Request", 4)
                     jsonRequest = json.dumps(json.loads(
-                        '{ "jsonrpc": "2.0", "id": 1234567890, "method": "%s" }' % method, object_pairs_hook=OrderedDict), indent=4)
+                        '{ "jsonrpc": "2.0", "id": 1234567890, "method": "%s" }'
+                        % method,
+                        object_pairs_hook=OrderedDict),
+                                             indent=4)
                     MdCode(jsonRequest, "json")
                     MdHeader("Get Response", 4)
-                    jsonResponse = json.dumps(json.loads('{ "jsonrpc": "2.0", "id": 1234567890, %s }' % __ExampleObj(
-                        "result", parameters), object_pairs_hook=OrderedDict), indent=4)
+                    jsonResponse = json.dumps(json.loads(
+                        '{ "jsonrpc": "2.0", "id": 1234567890, %s }' %
+                        __ExampleObj("result", parameters),
+                        object_pairs_hook=OrderedDict),
+                                              indent=4)
                     MdCode(jsonResponse, "json")
 
             if not readonly:
@@ -2140,15 +2333,23 @@ def CreateDocument(schema, path):
                     else:
                         MdHeader("Request", 4)
 
-                jsonRequest = json.dumps(json.loads('{ "jsonrpc": "2.0", %s"method": "%s"%s }' % ('"id": 1234567890, ' if not is_notification else "", method, (
-                    ", " + __ExampleObj("params", parameters)) if parameters else ""), object_pairs_hook=OrderedDict), indent=4)
+                jsonRequest = json.dumps(json.loads(
+                    '{ "jsonrpc": "2.0", %s"method": "%s"%s }' %
+                    ('"id": 1234567890, ' if not is_notification else "",
+                     method, (", " + __ExampleObj("params", parameters))
+                     if parameters else ""),
+                    object_pairs_hook=OrderedDict),
+                                         indent=4)
                 MdCode(jsonRequest, "json")
 
                 if not is_notification and not is_property:
                     if "result" in props:
                         MdHeader("Response", 4)
-                        jsonResponse = json.dumps(json.loads('{ "jsonrpc": "2.0", "id": 1234567890, %s }' % __ExampleObj(
-                            "result", props["result"]), object_pairs_hook=OrderedDict), indent=4)
+                        jsonResponse = json.dumps(json.loads(
+                            '{ "jsonrpc": "2.0", "id": 1234567890, %s }' %
+                            __ExampleObj("result", props["result"]),
+                            object_pairs_hook=OrderedDict),
+                                                  indent=4)
                         MdCode(jsonResponse, "json")
                     elif "noresult" not in props or not props["noresult"]:
                         raise RuntimeError("missing 'result' in %s" % method)
@@ -2156,12 +2357,16 @@ def CreateDocument(schema, path):
                 if is_property:
                     MdHeader("Set Response", 4)
                     jsonResponse = json.dumps(json.loads(
-                        '{ "jsonrpc": "2.0", "id": 1234567890, "result": "null" }', object_pairs_hook=OrderedDict), indent=4)
+                        '{ "jsonrpc": "2.0", "id": 1234567890, "result": "null" }',
+                        object_pairs_hook=OrderedDict),
+                                              indent=4)
                     MdCode(jsonResponse, "json")
 
         MdBody("<!-- Generated automatically, DO NOT EDIT! -->")
         commons = dict()
-        with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), GLOBAL_DEFINITIONS)) as f:
+        with open(
+                os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                             GLOBAL_DEFINITIONS)) as f:
             commons = json.load(f)
 
         info = schema["info"]
@@ -2205,8 +2410,9 @@ def CreateDocument(schema, path):
             rating = 3
         else:
             raise RuntimeError("invalid status")
-        MdParagraph(bold("Status: " + rating * ":black_circle:" +
-                         (3 - rating) * ":white_circle:"))
+        MdParagraph(
+            bold("Status: " + rating * ":black_circle:" +
+                 (3 - rating) * ":white_circle:"))
 
         plugin_class = None
         if "class" in info:
@@ -2232,7 +2438,10 @@ def CreateDocument(schema, path):
         MdBr()
 
         def mergedict(d1, d2, prop):
-            return {**(d1[prop] if prop in d1 else dict()), **(d2[prop] if prop in d2 else dict())}
+            return {
+                **(d1[prop] if prop in d1 else dict()),
+                **(d2[prop] if prop in d2 else dict())
+            }
 
         MdHeader("Introduction")
         MdHeader("Scope", 2)
@@ -2254,21 +2463,26 @@ def CreateDocument(schema, path):
                 extra = " and properties provided"
             elif event_count:
                 extra = " and notifications sent"
-            MdParagraph("This document describes purpose and functionality of the %s plugin. It includes detailed specification of its configuration%s." % (
-                plugin_class, extra))
+            MdParagraph(
+                "This document describes purpose and functionality of the %s plugin. It includes detailed specification of its configuration%s."
+                % (plugin_class, extra))
 
         MdHeader("Case Sensitivity", 2)
-        MdParagraph("All identifiers on the interface described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such.")
+        MdParagraph(
+            "All identifiers on the interface described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such."
+        )
         if "acronyms" in info or "acronyms" in commons or "terms" in info or "terms" in commons:
             MdHeader("Acronyms, Abbreviations and Terms", 2)
             if "acronyms" in info or "acronyms" in commons:
                 MdParagraph(
-                    "The table below provides and overview of acronyms used in this document and their definitions.")
+                    "The table below provides and overview of acronyms used in this document and their definitions."
+                )
                 PlainTable(mergedict(commons, info, "acronyms"),
                            ["Acronym", "Description"], "acronym")
             if "terms" in info or "terms" in commons:
                 MdParagraph(
-                    "The table below provides and overview of terms and abbreviations used in this document and their definitions.")
+                    "The table below provides and overview of terms and abbreviations used in this document and their definitions."
+                )
                 PlainTable(mergedict(commons, info, "terms"),
                            ["Term", "Description"], "term")
 
@@ -2286,47 +2500,76 @@ def CreateDocument(schema, path):
             MdParagraph(" ".join(info["description"]) if isinstance(
                 info["description"], list) else info["description"])
             MdParagraph(
-                "The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)].")
+                "The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)]."
+            )
 
         MdHeader("Configuration")
         commonConfig = OrderedDict()
-        if "configuration" in schema and "nodefault" in schema["configuration"] and schema["configuration"]["nodefault"] and "properties" not in schema["configuration"]:
+        if "configuration" in schema and "nodefault" in schema[
+                "configuration"] and schema["configuration"][
+                    "nodefault"] and "properties" not in schema["configuration"]:
             MdParagraph("The plugin does not take any configuration.")
         else:
             MdParagraph(
                 "The table below lists configuration options of the plugin.")
-            if "configuration" not in schema or ("nodefault" not in schema["configuration"] or not schema["configuration"]["nodefault"]):
+            if "configuration" not in schema or (
+                    "nodefault" not in schema["configuration"]
+                    or not schema["configuration"]["nodefault"]):
                 if "callsign" in info:
                     commonConfig["callsign"] = {
-                        "type": "string", "description": 'Plugin instance name (default: *%s*)' % info["callsign"]}
+                        "type":
+                        "string",
+                        "description":
+                        'Plugin instance name (default: *%s*)' %
+                        info["callsign"]
+                    }
                 if plugin_class:
                     commonConfig["classname"] = {
-                        "type": "string", "description": 'Class name: *%s*' % plugin_class}
+                        "type": "string",
+                        "description": 'Class name: *%s*' % plugin_class
+                    }
                 if "locator" in info:
                     commonConfig["locator"] = {
-                        "type": "string", "description": 'Library name: *%s*' % info["locator"]}
+                        "type": "string",
+                        "description": 'Library name: *%s*' % info["locator"]
+                    }
                 commonConfig["autostart"] = {
-                    "type": "boolean", "description": "Determines if the plugin is to be started automatically along with the framework"}
+                    "type":
+                    "boolean",
+                    "description":
+                    "Determines if the plugin is to be started automatically along with the framework"
+                }
 
             required = []
             if "configuration" in schema:
-                commonConfig2 = OrderedDict(commonConfig.items(
-                ) + schema["configuration"]["properties"].items())
-                required = schema["configuration"]["required"] if "required" in schema["configuration"] else [
-                ]
+                commonConfig2 = OrderedDict(
+                    commonConfig.items() +
+                    schema["configuration"]["properties"].items())
+                required = schema["configuration"][
+                    "required"] if "required" in schema[
+                        "configuration"] else []
             else:
                 commonConfig2 = commonConfig
 
             totalConfig = OrderedDict()
             totalConfig["type"] = "object"
             totalConfig["properties"] = commonConfig2
-            if "configuration" not in schema or ("nodefault" not in schema["configuration"] or not schema["configuration"]["nodefault"]):
-                totalConfig["required"] = ["callsign",
-                                           "classname", "locator", "autostart"] + required
+            if "configuration" not in schema or (
+                    "nodefault" not in schema["configuration"]
+                    or not schema["configuration"]["nodefault"]):
+                totalConfig["required"] = [
+                    "callsign", "classname", "locator", "autostart"
+                ] + required
 
             ParamTable("", totalConfig)
 
-        def SectionDump(section_name, section, header, description=None, description2=None, event=False, prop=False):
+        def SectionDump(section_name,
+                        section,
+                        header,
+                        description=None,
+                        description2=None,
+                        event=False,
+                        prop=False):
             skip_list = []
 
             def InterfaceDump(interface, section, header):
@@ -2335,15 +2578,18 @@ def CreateDocument(schema, path):
                     for method, contents in interface[section].items():
                         if contents and method not in skip_list:
                             if not head:
-                                MdParagraph("%s interface %s:" % (
-                                    interface["info"]["class"], section))
+                                MdParagraph(
+                                    "%s interface %s:" %
+                                    (interface["info"]["class"], section))
                                 MdTableHeader(
                                     [header.capitalize(), "Description"])
                                 head = True
                             access = ""
-                            if "readonly" in contents and contents["readonly"] == True:
+                            if "readonly" in contents and contents[
+                                    "readonly"] == True:
                                 access = "RO"
-                            elif "writeonly" in contents and contents["writeonly"] == True:
+                            elif "writeonly" in contents and contents[
+                                    "writeonly"] == True:
                                 access = "WO"
                             if access:
                                 access = " <sup>%s</sup>" % access
@@ -2356,16 +2602,19 @@ def CreateDocument(schema, path):
                                     descr = descr[0:descr.index("i.e") - 1]
                                 descr = descr.split(
                                     ".", 1)[0] if "." in descr else descr
-                            MdRow([link(header + "." + (method.rsplit(".", 1)[1]
-                                                        if "." in method else method)) + access, descr])
+                            MdRow([
+                                link(header + "." +
+                                     (method.rsplit(".", 1)[1] if "." in
+                                      method else method)) + access, descr
+                            ])
                         skip_list.append(method)
 
             MdHeader(section_name)
             if description:
                 MdParagraph(description)
 
-            MdParagraph("The following %s are provided by the %s plugin:" % (
-                section, plugin_class))
+            MdParagraph("The following %s are provided by the %s plugin:" %
+                        (section, plugin_class))
             InterfaceDump(interface, section, header)
             if "include" in interface:
                 for _, s in interface["include"].items():
@@ -2393,8 +2642,8 @@ def CreateDocument(schema, path):
                         if section in s:
                             for method, props in s[section].items():
                                 if props and method not in skip_list:
-                                    MethodDump(method, props,
-                                               plugin_class, event, prop, cl)
+                                    MethodDump(method, props, plugin_class,
+                                               event, prop, cl)
 
         if method_count:
             SectionDump("Methods", "methods", "method")
@@ -2403,8 +2652,12 @@ def CreateDocument(schema, path):
             SectionDump("Properties", "properties", "property", prop=True)
 
         if event_count:
-            SectionDump("Notifications", "events", "event",
-                        "Notifications are autonomous events, triggered by the internals of the plugin, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.", event=True)
+            SectionDump(
+                "Notifications",
+                "events",
+                "event",
+                "Notifications are autonomous events, triggered by the internals of the plugin, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.",
+                event=True)
 
         trace.Success("Document created: %s" % output_path)
 
@@ -2416,41 +2669,137 @@ enumTracker = EnumTracker()
 
 if __name__ == "__main__":
     argparser = argparse.ArgumentParser(
-        description='Generate JSON C++ classes, stub code and API documentation from JSON definition files.', formatter_class=argparse.RawTextHelpFormatter)
+        description=
+        'Generate JSON C++ classes, stub code and API documentation from JSON definition files.',
+        formatter_class=argparse.RawTextHelpFormatter)
+    argparser.add_argument('path',
+                           nargs="*",
+                           help="JSON file(s), wildcards are allowed")
+    argparser.add_argument("--version",
+                           dest="version",
+                           action="store_true",
+                           default=False,
+                           help="display version")
+    argparser.add_argument("-d",
+                           "--docs",
+                           dest="docs",
+                           action="store_true",
+                           default=False,
+                           help="generate documentation")
     argparser.add_argument(
-        'path', nargs="*", help="JSON file(s), wildcards are allowed")
-    argparser.add_argument("--version", dest="version",
-                           action="store_true", default=False, help="display version")
-    argparser.add_argument("-d", "--docs", dest="docs", action="store_true",
-                           default=False, help="generate documentation")
-    argparser.add_argument("-c", "--code", dest="code", action="store_true",
-                           default=False, help="generate JSON classes and JSON-RPC code if applicable")
-    argparser.add_argument("-s", "--stubs", dest="stubs", action="store_true",
-                           default=False, help="generate JSON-RPC stub code")
-    argparser.add_argument("-p", dest="if_path", metavar="PATH", action="store", type=str, default=IF_PATH,
-                           help="relative path for #include'ing JsonData header file (default: 'interfaces/json', '.' for no path)")
-    argparser.add_argument("-i", dest="if_dir", metavar="DIR", action="store", type=str, default=None,
-                           help="a directory with JSON API interfaces that will substitute the {interfacedir} tag (default: same directory as source file)")
-    argparser.add_argument("-j", dest="cppif_dir", metavar="DIR", action="store", type=str, default=None,
-                           help="a directory with C++ API interfaces that will substitute the {cppinterfacedir} tag (default: same directory as source file)")
-    argparser.add_argument("-o", "--output", dest="output_dir", metavar="DIR", action="store", default=None,
-                           help="output directory, absolute path or directory relative to output file(default: output in the same directory as the source json)")
-    argparser.add_argument("--indent", dest="indent_size", metavar="SIZE", type=int, action="store",
-                           default=INDENT_SIZE, help="code indentation in spaces (default: %i)" % INDENT_SIZE)
-    argparser.add_argument("--dump-json", dest="dump_json", action="store_true",
-                           default=False, help="dump intermediate JSON file when parsing C++ header")
-    argparser.add_argument("--copy-ctor", dest="copy_ctor", action="store_true", default=False,
-                           help="always emit a copy constructor and assignment operator for a class (default: emit only when it appears to be needed)")
-    argparser.add_argument("--keep-empty", dest="keep_empty", action="store_true", default=False,
-                           help="keep generated files that have no content (default: remove empty cpp/h files)")
-    argparser.add_argument("--no-ref-names", dest="no_ref_names", action="store_true", default=False,
-                           help="do not derive class names from $refs (default: derive class names from $ref)")
-    argparser.add_argument("--def-string", dest="def_string", metavar="STRING", type=str, action="store",
-                           default=DEFAULT_EMPTY_STRING, help="default string initialisation (default: \"%s\")" % DEFAULT_EMPTY_STRING)
-    argparser.add_argument("--def-int-size", dest="def_int_size", metavar="SIZE", type=int, action="store",
-                           default=DEFAULT_INT_SIZE, help="default integer size in bits (default: %i)" % DEFAULT_INT_SIZE)
-    argparser.add_argument("--no-warnings", dest="no_warnings", action="store_true",
-                           default=False, help="suppress style/wording warnings (default: show all warnings)")
+        "-c",
+        "--code",
+        dest="code",
+        action="store_true",
+        default=False,
+        help="generate JSON classes and JSON-RPC code if applicable")
+    argparser.add_argument("-s",
+                           "--stubs",
+                           dest="stubs",
+                           action="store_true",
+                           default=False,
+                           help="generate JSON-RPC stub code")
+    argparser.add_argument(
+        "-p",
+        dest="if_path",
+        metavar="PATH",
+        action="store",
+        type=str,
+        default=IF_PATH,
+        help=
+        "relative path for #include'ing JsonData header file (default: 'interfaces/json', '.' for no path)"
+    )
+    argparser.add_argument(
+        "-i",
+        dest="if_dir",
+        metavar="DIR",
+        action="store",
+        type=str,
+        default=None,
+        help=
+        "a directory with JSON API interfaces that will substitute the {interfacedir} tag (default: same directory as source file)"
+    )
+    argparser.add_argument(
+        "-j",
+        dest="cppif_dir",
+        metavar="DIR",
+        action="store",
+        type=str,
+        default=None,
+        help=
+        "a directory with C++ API interfaces that will substitute the {cppinterfacedir} tag (default: same directory as source file)"
+    )
+    argparser.add_argument(
+        "-o",
+        "--output",
+        dest="output_dir",
+        metavar="DIR",
+        action="store",
+        default=None,
+        help=
+        "output directory, absolute path or directory relative to output file(default: output in the same directory as the source json)"
+    )
+    argparser.add_argument("--indent",
+                           dest="indent_size",
+                           metavar="SIZE",
+                           type=int,
+                           action="store",
+                           default=INDENT_SIZE,
+                           help="code indentation in spaces (default: %i)" %
+                           INDENT_SIZE)
+    argparser.add_argument(
+        "--dump-json",
+        dest="dump_json",
+        action="store_true",
+        default=False,
+        help="dump intermediate JSON file when parsing C++ header")
+    argparser.add_argument(
+        "--copy-ctor",
+        dest="copy_ctor",
+        action="store_true",
+        default=False,
+        help=
+        "always emit a copy constructor and assignment operator for a class (default: emit only when it appears to be needed)"
+    )
+    argparser.add_argument(
+        "--keep-empty",
+        dest="keep_empty",
+        action="store_true",
+        default=False,
+        help=
+        "keep generated files that have no content (default: remove empty cpp/h files)"
+    )
+    argparser.add_argument(
+        "--no-ref-names",
+        dest="no_ref_names",
+        action="store_true",
+        default=False,
+        help=
+        "do not derive class names from $refs (default: derive class names from $ref)"
+    )
+    argparser.add_argument(
+        "--def-string",
+        dest="def_string",
+        metavar="STRING",
+        type=str,
+        action="store",
+        default=DEFAULT_EMPTY_STRING,
+        help="default string initialisation (default: \"%s\")" %
+        DEFAULT_EMPTY_STRING)
+    argparser.add_argument("--def-int-size",
+                           dest="def_int_size",
+                           metavar="SIZE",
+                           type=int,
+                           action="store",
+                           default=DEFAULT_INT_SIZE,
+                           help="default integer size in bits (default: %i)" %
+                           DEFAULT_INT_SIZE)
+    argparser.add_argument(
+        "--no-warnings",
+        dest="no_warnings",
+        action="store_true",
+        default=False,
+        help="suppress style/wording warnings (default: show all warnings)")
     args = argparser.parse_args(sys.argv[1:])
     VERIFY = not args.no_warnings
     INDENT_SIZE = args.indent_size
@@ -2477,7 +2826,8 @@ if __name__ == "__main__":
     if args.version:
         print("Version: {}".format(VERSION))
         sys.exit(1)
-    elif not args.path or (not generateCode and not generateRpc and not generateStubs and not generateDocs):
+    elif not args.path or (not generateCode and not generateRpc
+                           and not generateStubs and not generateDocs):
         argparser.print_help()
     else:
         files = []
@@ -2496,22 +2846,27 @@ if __name__ == "__main__":
                         if args.output_dir:
                             if (args.output_dir[0]) == '/':
                                 output_path = os.path.join(
-                                    args.output_dir, os.path.basename(output_path))
+                                    args.output_dir,
+                                    os.path.basename(output_path))
                             else:
-                                dir = os.path.join(os.path.dirname(
-                                    output_path), args.output_dir)
+                                dir = os.path.join(os.path.dirname(output_path),
+                                                   args.output_dir)
                                 if not os.path.exists(dir):
                                     os.makedirs(dir)
                                 output_path = os.path.join(
                                     dir, os.path.basename(output_path))
                         if generateCode or generateStubs or generateRpc:
-                            CreateCode(schema, output_path,
-                                       generateCode, generateStubs, generateRpc)
+                            CreateCode(schema, output_path, generateCode,
+                                       generateStubs, generateRpc)
                         if generateDocs:
-                            title = schema["info"]["title"] if "title" in schema else schema["info"]["class"] if "class" in schema else os.path.basename(
-                                output_path)
-                            CreateDocument(schema, os.path.join(
-                                os.path.dirname(output_path), title.replace(" ", "")))
+                            title = schema["info"][
+                                "title"] if "title" in schema else schema["info"][
+                                    "class"] if "class" in schema else os.path.basename(
+                                        output_path)
+                            CreateDocument(
+                                schema,
+                                os.path.join(os.path.dirname(output_path),
+                                             title.replace(" ", "")))
             except JsonParseError as err:
                 trace.Error(str(err))
             except RuntimeError as err:
@@ -2521,6 +2876,7 @@ if __name__ == "__main__":
             except ValueError as err:
                 trace.Error(str(err))
         print("\nJsonGenerator: All done. {} error{}.".format(
-            trace.errors if trace.errors else 'No', '' if trace.errors == 1 else 's'))
+            trace.errors if trace.errors else 'No',
+            '' if trace.errors == 1 else 's'))
         if trace.errors:
             sys.exit(1)

--- a/Tools/ProxyStubGenerator/CppParser.py
+++ b/Tools/ProxyStubGenerator/CppParser.py
@@ -438,7 +438,7 @@ class Variable(Type, Identifier):
     def __repr__(self):
         return str(self)
 
-class Parameter(Type, Variable):
+class Parameter(Variable, Type):
     def __init__(self, parent_block, string, value = [], valid_specifiers = []):
         Variable.__init__(self, parent_block, string, value, valid_specifiers)
         if self.name in parent_block.param:
@@ -478,7 +478,7 @@ class Enumerator(Type, Identifier):
         Identifier.__init__(self, parent_enum, self.name)
         self.parent = parent_block
         self.value = parent_block.GetValue() if value == None else Evaluate(value)
-        if isinstance(self.value, (int, long)):
+        if isinstance(self.value, (int)):
             self.parent.SetValue(self.value)
         self.parent.items.append(self)
     def __str__(self):
@@ -1070,22 +1070,22 @@ def DumpTree(tree, ind = 0):
     indent = ind*" "
 
     if isinstance(tree, (Namespace, Class)):
-        print indent + str(tree)
+        print(indent + str(tree))
 
         for td in tree.typedefs:
-            print indent + 2*" " + str(td)
+            print(indent + 2*" " + str(td))
 
         for e in tree.enums:
-            print indent + 2*" " + str(e)
+            print(indent + 2*" " + str(e))
             for item in e.items:
-                print indent + 4*" " + str(item)
+                print(indent + 4*" " + str(item))
 
     for v in tree.vars:
-        print indent + 2*" " + str(v)
+        print(indent + 2*" " + str(v))
 
     if isinstance(tree, (Namespace, Class)):
         for m in tree.methods:
-           print indent + 2*" " + str(m)
+           print(indent + 2*" " + str(m))
 
     if isinstance(tree, (Namespace, Class)):
         for c in tree.classes:
@@ -1103,4 +1103,4 @@ if __name__ == "__main__":
     if isinstance(tree, Namespace):
          DumpTree(tree)
     else:
-        print tree
+        print(tree)

--- a/Tools/ProxyStubGenerator/CppParser.py
+++ b/Tools/ProxyStubGenerator/CppParser.py
@@ -7,15 +7,22 @@
 import re, uuid, sys
 from collections import OrderedDict
 
+
 class ParserError(RuntimeError):
+
     def __init__(self, msg):
         msg = "%s(%s): parse error: %s" % (CurrentFile(), CurrentLine(), msg)
         super(ParserError, self).__init__(msg)
 
+
 # Checks if identifier is valid.
 def is_valid(token):
-    if "operator" in token: return re.match(r'^[-\+~<>=!%&^*/\|\[\]]+$', token[8:])
-    else: return token and re.match(r'^[a-zA-Z0-9_~]+$', token) and not token[0].isdigit()
+    if "operator" in token:
+        return re.match(r'^[-\+~<>=!%&^*/\|\[\]]+$', token[8:])
+    else:
+        return token and re.match(r'^[a-zA-Z0-9_~]+$',
+                                  token) and not token[0].isdigit()
+
 
 def ASSERT_ISVALID(token):
     if not is_valid(token):
@@ -23,9 +30,12 @@ def ASSERT_ISVALID(token):
     elif token in ["alignas", "alignof"]:
         raise ParserError("aligment specifiers are not supported")
 
+
 def ASSERT_ISEXPECTED(token, list):
     if token not in list:
-        raise ParserError("unexpected identifier: '" + token + "', expected one of " + str(list))
+        raise ParserError("unexpected identifier: '" + token +
+                          "', expected one of " + str(list))
+
 
 # -------------------------------------------------------------------------
 # CLASS DEFINITIONS
@@ -33,9 +43,15 @@ def ASSERT_ISEXPECTED(token, list):
 
 global_namespace = None
 
+
 # Holds identifier type
 class Type:
-    def __init__(self, parent_block, string, valid_specifiers, tags_allowed = True):
+
+    def __init__(self,
+                 parent_block,
+                 string,
+                 valid_specifiers,
+                 tags_allowed=True):
         self.parent = parent_block
         self.name = ""
         self.brief = ""
@@ -49,7 +65,7 @@ class Type:
         self.interface = None
         self.param = OrderedDict()
         self.retval = OrderedDict()
-        type = ["?"] # indexing safety
+        type = ["?"]  # indexing safety
         type_found = False
         nest1 = 0
         nest2 = 0
@@ -57,13 +73,18 @@ class Type:
         skip = 0
 
         if string.count("*") > 1:
-            raise ParserError("pointers to pointers are not supported: '%s'" % (" ".join(string)))
+            raise ParserError("pointers to pointers are not supported: '%s'" %
+                              (" ".join(string)))
         elif string.count("[") > 1:
-            raise ParserError("multi-dimensional arrays are not supported: '%s'" % (" ".join(string)))
+            raise ParserError(
+                "multi-dimensional arrays are not supported: '%s'" %
+                (" ".join(string)))
         elif "[" in string and "*" in string:
-            raise ParserError("arrays of pointers are not supported: '%s'" % (" ".join(string)))
-        elif "&&" in string :
-            raise ParserError("rvalue references are not supported: '%s'" % (" ".join(string)))
+            raise ParserError("arrays of pointers are not supported: '%s'" %
+                              (" ".join(string)))
+        elif "&&" in string:
+            raise ParserError("rvalue references are not supported: '%s'" %
+                              (" ".join(string)))
 
         for i, token in enumerate(string):
             if skip > 0:
@@ -98,12 +119,14 @@ class Type:
                     if tags_allowed:
                         self.input = True
                     else:
-                        raise ParserError("in/out tags not allowed on return value")
+                        raise ParserError(
+                            "in/out tags not allowed on return value")
                 elif token[1:] == "OUT":
                     if tags_allowed:
                         self.output = True
                     else:
-                        raise ParserError("in/out tags not allowed on return value")
+                        raise ParserError(
+                            "in/out tags not allowed on return value")
                 elif token[1:] == "LENGTH":
                     self.length = string[i + 1]
                     skip = 1
@@ -112,7 +135,8 @@ class Type:
                     if tags_allowed:
                         self.maxlength = string[i + 1]
                     else:
-                        raise ParserError("maxlength tag not allowed on return value")
+                        raise ParserError(
+                            "maxlength tag not allowed on return value")
                     skip = 1
                     continue
                 elif token[1:] == "INTERFACE":
@@ -127,10 +151,10 @@ class Type:
                     self.details = string[i + 1]
                     skip = 1
                 elif token[1:] == "PARAM":
-                    self.param[string[i+1]] = string[i+2]
+                    self.param[string[i + 1]] = string[i + 2]
                     skip = 2
                 elif token[1:] == "RETVAL":
-                    self.retval[string[i+1]] = string[i+2]
+                    self.retval[string[i + 1]] = string[i + 2]
                     skip = 2
                 else:
                     raise ParserError("invalid tag: " + token)
@@ -138,7 +162,7 @@ class Type:
             # skip C-style explicit struct
             elif token in ["struct", "class", "union"]:
                 continue
-            elif token in ["export"]: # skip
+            elif token in ["export"]:  # skip
                 continue
 
             # keep identifers with scope operator together
@@ -177,11 +201,16 @@ class Type:
 
             elif not type_found and not array:
                 # handle primitive type combinations...
-                if (token in ["int"]) and (type[-1].split()[-1] in ["signed", "unsigned", "short", "long"]):
+                if (token in ["int"]) and (type[-1].split()[-1] in [
+                        "signed", "unsigned", "short", "long"
+                ]):
                     type[-1] += " " + token
-                elif (token in ["char", "short", "long"]) and (type[-1].split()[-1] in ["signed", "unsigned"]):
+                elif (token in [
+                        "char", "short", "long"
+                ]) and (type[-1].split()[-1] in ["signed", "unsigned"]):
                     type[-1] += " " + token
-                elif (token in ["long", "double"]) and (type[-1].split()[-1] in ["long"]):
+                elif (token in ["long", "double"
+                                ]) and (type[-1].split()[-1] in ["long"]):
                     type[-1] += " " + token
                 # keep identifers with scope operator together
                 elif type[-1].endswith("::"):
@@ -192,7 +221,9 @@ class Type:
                 else:
                     type[-1] += token
 
-                if ((i == len(string) - 1) or (string[i + 1] not in ["char", "short", "long", "int", "double"])):
+                if ((i == len(string) - 1) or (string[i + 1] not in [
+                        "char", "short", "long", "int", "double"
+                ])):
                     type_found = True
 
             elif type_found:
@@ -211,59 +242,83 @@ class Type:
             parent = parent.parent
 
         if self.type:
+
             def __Search(tree, found, T):
                 qualifiedT = "::" + T
 
                 # need full qualification if the class is a subclass
                 if tree.full_name.startswith(parent.full_name + "::"):
-                    if T.count("::") != tree.full_name.replace(parent.full_name, "").count("::"):
+                    if T.count("::") != tree.full_name.replace(
+                            parent.full_name, "").count("::"):
                         return
 
-                enum_match = [e for e in tree.enums if e.full_name.endswith(qualifiedT)]
-                typedef_match = [td for td in tree.typedefs if td.full_name.endswith(qualifiedT)]
-                class_match = [cl for cl in tree.classes if cl.full_name.endswith(qualifiedT)]
+                enum_match = [
+                    e for e in tree.enums if e.full_name.endswith(qualifiedT)
+                ]
+                typedef_match = [
+                    td for td in tree.typedefs
+                    if td.full_name.endswith(qualifiedT)
+                ]
+                class_match = [
+                    cl for cl in tree.classes
+                    if cl.full_name.endswith(qualifiedT)
+                ]
 
                 found += enum_match + typedef_match + class_match
 
-                if isinstance(tree, (Namespace, Class)) :
+                if isinstance(tree, (Namespace, Class)):
                     for c in tree.classes:
                         __Search(c, found, T)
 
                 if isinstance(tree, Namespace):
                     for n in tree.namespaces:
-                       __Search(n, found, T)
+                        __Search(n, found, T)
 
             # find the type to scan for...
             i = -1
             while self.type[i] in ["*", "&", "const", "volatile"]:
                 i -= 1
 
-            if self.type[i] not in ["bool", "int", "char", "wchar_t", "short", "long", "signed", "unsigned", "void", "float", "double",
-                                    "int8_t", "uint8_t", "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t", "uint64_t", "size_t"]:
+            if self.type[i] not in [
+                    "bool", "int", "char", "wchar_t", "short", "long", "signed",
+                    "unsigned", "void", "float", "double", "int8_t", "uint8_t",
+                    "int16_t", "uint16_t", "int32_t", "uint32_t", "int64_t",
+                    "uint64_t", "size_t"
+            ]:
                 found = []
                 __Search(global_namespace, found, self.type[i])
                 if found:
-                    self.type[i] = found[-1] # take closest match
+                    self.type[i] = found[-1]  # take closest match
 
     def __str__(self):
         return " ".join(self.type)
+
     def __repr__(self):
         return str(self)
+
     def Type(self):
         return self.type
+
 
 def Evaluate(identifiers):
     val = []
     if identifiers:
         for identifier in identifiers:
             try:
-                val.append(str(int(identifier,16 if identifier[:2] == "0x" else 10)))
+                val.append(
+                    str(int(identifier, 16 if identifier[:2] == "0x" else 10)))
             except:
+
                 def __Search(tree, found, T):
-                    var_match = [v for v in tree.vars if v.full_name.endswith(T)]
+                    var_match = [
+                        v for v in tree.vars if v.full_name.endswith(T)
+                    ]
                     enumerator_match = []
                     for e in tree.enums:
-                        enumerator_match += [item for item in e.items if item.full_name.endswith(T)]
+                        enumerator_match += [
+                            item for item in e.items
+                            if item.full_name.endswith(T)
+                        ]
 
                     found += var_match + enumerator_match
 
@@ -295,40 +350,54 @@ def Evaluate(identifiers):
 
     return val
 
+
 # Holds identifier commons
 class Identifier:
-    def __init__(self, parent_block, name = ""):
+
+    def __init__(self, parent_block, name=""):
         if name:
             ASSERT_ISVALID(name)
         self.parent = parent_block
         # come up with an unique name if none given
-        self.name = "__unnamed_" + self.__class__.__name__.lower() + "_" + uuid.uuid4().hex[:8] if (not name and self.parent != None) else name
-        self.full_name = ("" if self.parent == None else self.parent.full_name) + ("" if not self.name else "::" + self.name)
+        self.name = "__unnamed_" + self.__class__.__name__.lower(
+        ) + "_" + uuid.uuid4().hex[:8] if (not name
+                                           and self.parent != None) else name
+        self.full_name = ("" if self.parent == None else self.parent.full_name
+                          ) + ("" if not self.name else "::" + self.name)
         self.parser_file = CurrentFile()
         self.parser_line = CurrentLine()
+
     def __str__(self):
         return self.full_name
+
     def __repr__(self):
         return str(self)
+
     def Name(self):
         return self.full_name
 
+
 # Holds type definition
 class Typedef(Type, Identifier):
+
     def __init__(self, parent_block, string):
         Type.__init__(self, parent_block, string, [])
         Identifier.__init__(self, parent_block, self.name)
         self.parent = parent_block
         self.parent.typedefs.append(self)
         self.is_event = False
+
     def __str__(self):
         return "typedef " + self.full_name + " -> " + str(self.type)
+
     def __repr__(self):
         return str(self)
 
+
 # Holds compound statements and composite types
 class Block(Identifier):
-    def __init__(self, parent_block, name = ""):
+
+    def __init__(self, parent_block, name=""):
         Identifier.__init__(self, parent_block, name)
         self.vars = []
         self.enums = []
@@ -337,50 +406,62 @@ class Block(Identifier):
         self.unions = []
         self.parser_file = CurrentFile()
         self.parser_line = CurrentLine()
+
     def __str__(self):
         return self.full_name
+
     def __repr__(self):
         return str(self)
 
+
 # Holds namespaces
 class Namespace(Block):
-    def __init__(self, parent_block, name = ""):
+
+    def __init__(self, parent_block, name=""):
         Block.__init__(self, parent_block, name)
         self.namespaces = []
         self.methods = []
         self.omit = False
-        self.stub =-False
-        if self.parent != None: # case for global namespace
+        self.stub = -False
+        if self.parent != None:  # case for global namespace
             self.parent.namespaces.append(self)
+
     def __str__(self):
         return "namespace " + (self.full_name if self.full_name else "<global>")
+
     def __repr__(self):
         return str(self)
 
+
 # Holds structs and classes
 class Class(Block):
+
     def __init__(self, parent_block, name):
         Block.__init__(self, parent_block, name)
         self.specifiers = []
         self.methods = []
         self.classes = []
-        self.ancestors = [] # parent classes
+        self.ancestors = []  # parent classes
         self._current_access = "public"
         self.omit = False
         self.stub = False
         self.is_json = False
         self.is_event = False
         self.parent.classes.append(self)
+
     def __str__(self):
         astr = ""
         if self.ancestors:
             astr = " [: " + ", ".join(str(a[0]) for a in self.ancestors) + "]"
         return "class %s %s%s" % (self.specifiers, self.full_name, astr)
+
     def __repr__(self):
         return str(self)
 
+
 # Holds unions
 class Union(Block):
+
     def __init__(self, parent_block, name):
         Block.__init__(self, parent_block, name)
         self.methods = []
@@ -389,100 +470,151 @@ class Union(Block):
         self.omit = False
         self.stub = False
         self.parent.unions.append(self)
+
     def __str__(self):
         return "union " + self.full_name
+
     def __repr__(self):
         return str(self)
 
+
 # Holds enumeration blocks, including class enums
 class Enum(Block):
-    def __init__(self, parent_block, name, is_scoped, base_type = "int"):
+
+    def __init__(self, parent_block, name, is_scoped, base_type="int"):
         Block.__init__(self, parent_block, name)
         self.items = []
         self.scoped = is_scoped
         self.base_type = base_type
         self.parent.enums.append(self)
-        self._last_value = 0 # used for auto-incrementation
+        self._last_value = 0  # used for auto-incrementation
+
     def __str__(self):
-        return ("enum" if not self.scoped else "enum class") + " " + self.full_name
+        return ("enum"
+                if not self.scoped else "enum class") + " " + self.full_name
+
     def __repr__(self):
         return str(self)
+
     def SetValue(self, value):
         self._last_value = value + 1
+
     def GetValue(self):
         return self._last_value
 
+
 # Holds functions
 class Function(Type, Block, Identifier):
-    def __init__(self, parent_block, name, ret_type, valid_specifiers = ["static", "extern", "inline"]):
+
+    def __init__(self,
+                 parent_block,
+                 name,
+                 ret_type,
+                 valid_specifiers=["static", "extern", "inline"]):
         Type.__init__(self, parent_block, ret_type, valid_specifiers, False)
         Block.__init__(self, parent_block, name if name else self.name)
         Identifier.__init__(self, parent_block, self.name)
         self.omit = False
         self.stub = False
         self.parent.methods.append(self)
+
     def __str__(self):
-        return "function " + str(self.specifiers) + " " + str(self.type) + " '" + self.name + "' (" + str(self.vars) + ")"
+        return "function " + str(self.specifiers) + " " + str(
+            self.type) + " '" + self.name + "' (" + str(self.vars) + ")"
+
     def __repr__(self):
         return str(self)
 
+
 # Holds variables and constants
 class Variable(Type, Identifier):
-    def __init__(self, parent_block, string, value = [], valid_specifiers = ["static", "extern", "register"]):
+
+    def __init__(self,
+                 parent_block,
+                 string,
+                 value=[],
+                 valid_specifiers=["static", "extern", "register"]):
         Type.__init__(self, parent_block, string, valid_specifiers)
         Identifier.__init__(self, parent_block, self.name)
         self.value = Evaluate(value) if value else None
         self.parent.vars.append(self)
+
     def __str__(self):
-        return "variable %s %s '%s' [= %s]" % (str(self.specifiers), str(self.type), str(self.name), str(self.value))
+        return "variable %s %s '%s' [= %s]" % (str(
+            self.specifiers), str(self.type), str(self.name), str(self.value))
+
     def __repr__(self):
         return str(self)
 
+
 class Parameter(Variable, Type):
-    def __init__(self, parent_block, string, value = [], valid_specifiers = []):
+
+    def __init__(self, parent_block, string, value=[], valid_specifiers=[]):
         Variable.__init__(self, parent_block, string, value, valid_specifiers)
         if self.name in parent_block.param:
             self.brief = parent_block.param[self.name]
+
     def __str__(self):
-        return "param %s '%s' [= %s]" % ( str(self.type), str(self.name), str(self.value))
+        return "param %s '%s' [= %s]" % (str(self.type), str(
+            self.name), str(self.value))
+
     def __repr__(self):
         return str(self)
+
 
 # Holds member attributes
 class Method(Function):
+
     def __init__(self, parent_block, name, ret_type):
-        Function.__init__(self, parent_block, name, ret_type, ["inline", "static", "virtual", "explicit", "constexpr", "friend"])
+        Function.__init__(
+            self, parent_block, name, ret_type,
+            ["inline", "static", "virtual", "explicit", "constexpr", "friend"])
         self.access = self.parent._current_access
         self.qualifiers = []
+
     def __str__(self):
         return "method [" + self.access +  ":] " + str(self.specifiers) + " " + str(self.type) + " '" + self.name + "' (" \
                     + str(self.vars) + ") " + str(self.qualifiers)
+
     def __repr__(self):
         return str(self)
+
 
 # Holds member attributes and constants
 class Attribute(Variable):
-    def __init__(self, parent_block, string, value = []):
-        Variable.__init__(self, parent_block, string, value, ["static", "constexpr", "thread_local", "mutable"])
+
+    def __init__(self, parent_block, string, value=[]):
+        Variable.__init__(self, parent_block, string, value,
+                          ["static", "constexpr", "thread_local", "mutable"])
         self.access = self.parent._current_access
+
     def __str__(self):
-        return "attribute [%s:] %s %s '%s' [= %s]" % (self.access, str(self.specifiers), self.type, str(self.name), str(self.value))
+        return "attribute [%s:] %s %s '%s' [= %s]" % (
+            self.access, str(self.specifiers), self.type, str(
+                self.name), str(self.value))
+
     def __repr__(self):
         return str(self)
 
+
 # Holds enumeration items
 class Enumerator(Type, Identifier):
-    def __init__(self, parent_block, name, value = None, base_type = "int"):
+
+    def __init__(self, parent_block, name, value=None, base_type="int"):
         parent_enum = parent_block if parent_block.scoped else parent_block.parent
         Type.__init__(self, parent_enum, [base_type, name], [])
         Identifier.__init__(self, parent_enum, self.name)
         self.parent = parent_block
-        self.value = parent_block.GetValue() if value == None else Evaluate(value)
+        self.value = parent_block.GetValue() if value == None else Evaluate(
+            value)
         if isinstance(self.value, (int)):
             self.parent.SetValue(self.value)
         self.parent.items.append(self)
+
     def __str__(self):
-        return "enumerator %s '%s' []= %s]" % (str(self.type), str(self.full_name), str(self.value))
+        return "enumerator %s '%s' []= %s]" % (str(
+            self.type), str(self.full_name), str(self.value))
+
     def __repr__(self):
         return str(self)
 
@@ -491,12 +623,16 @@ class Enumerator(Type, Identifier):
 # PRIVATE FUNCTIONS
 # -------------------------------------------------------------------------
 
+
 # Source file test into a list of tokens, removing comments and preprocessor directives.
 def __Tokenize(contents):
     global current_file
     global current_line
 
-    tokens = [s.strip() for s in re.split(r"([\r\n])", contents, flags=re.MULTILINE) if s]
+    tokens = [
+        s.strip() for s in re.split(r"([\r\n])", contents, flags=re.MULTILINE)
+        if s
+    ]
     eoltokens = []
     line = 1
     for token in tokens:
@@ -514,36 +650,43 @@ def __Tokenize(contents):
     contents = "\n".join(eoltokens)
 
     formula = (
-            r"(#if 0[\S\s]*?#endif)"
-            r"|(#.*)"                                                                # preprocessor
-            r"|(/\*[\S\s]*?\*/)"                                                     # multi-line comments
-            r"|(//.*)"                                                               # single line comments
-            r"|(\"[^\"]+\")"                                                         # double quotes
-            r"|(\'[^\']+\')"                                                         # quotes
-            r"|(::)|(==)|(!=)|(>=)|(<=)|(&&)|(\|\|)"                                 # two-char operators
-            r"|(\+\+)|(--)|(\+=)|(-=)|(/=)|(\*=)|(%=)|(^=)|(&=)|(\|=)|(~=)"
-            r"|([,:;~!?=^/*%-\+&<>\{\}\(\)\[\]])"                                    # single-char operators
-            r"|([\r\n\t ])"                                                          # whitespace
-        )
+        r"(#if 0[\S\s]*?#endif)"
+        r"|(#.*)"  # preprocessor
+        r"|(/\*[\S\s]*?\*/)"  # multi-line comments
+        r"|(//.*)"  # single line comments
+        r"|(\"[^\"]+\")"  # double quotes
+        r"|(\'[^\']+\')"  # quotes
+        r"|(::)|(==)|(!=)|(>=)|(<=)|(&&)|(\|\|)"  # two-char operators
+        r"|(\+\+)|(--)|(\+=)|(-=)|(/=)|(\*=)|(%=)|(^=)|(&=)|(\|=)|(~=)"
+        r"|([,:;~!?=^/*%-\+&<>\{\}\(\)\[\]])"  # single-char operators
+        r"|([\r\n\t ])"  # whitespace
+    )
 
-    tokens = [s.strip() for s in re.split(formula, contents, flags=(re.MULTILINE)) if s]
+    tokens = [
+        s.strip() for s in re.split(formula, contents, flags=(re.MULTILINE))
+        if s
+    ]
 
     tagtokens = []
     # check for special metadata within comments
     for token in tokens:
         if token:
+
             def __ParseLength(string, tag):
                 formula = (
-                            r"(\"[^\"]+\")"
-                            r"|(\'[^\']+\')"
-                            r"|(\*/)|(::)|(==)|(!=)|(>=)|(<=)|(&&)|(\|\|)"
-                            r"|(\+\+)|(--)|(\+=)|(-=)|(/=)|(\*=)|(%=)|(^=)|(&=)|(\|=)|(~=)"
-                            r"|([,:;~!?=^/*%-\+&<>\{\}\(\)\[\]])"
-                            r"|([\r\n\t ])"
-                        )
+                    r"(\"[^\"]+\")"
+                    r"|(\'[^\']+\')"
+                    r"|(\*/)|(::)|(==)|(!=)|(>=)|(<=)|(&&)|(\|\|)"
+                    r"|(\+\+)|(--)|(\+=)|(-=)|(/=)|(\*=)|(%=)|(^=)|(&=)|(\|=)|(~=)"
+                    r"|([,:;~!?=^/*%-\+&<>\{\}\(\)\[\]])"
+                    r"|([\r\n\t ])")
                 tagtokens.append(tag.upper())
-                length_str = string[string.index(tag)+len(tag):]
-                length_tokens = [s.strip() for s in re.split(formula, length_str, flags=re.MULTILINE) if isinstance(s, str) and len(s.strip())]
+                length_str = string[string.index(tag) + len(tag):]
+                length_tokens = [
+                    s.strip()
+                    for s in re.split(formula, length_str, flags=re.MULTILINE)
+                    if isinstance(s, str) and len(s.strip())
+                ]
                 if length_tokens[0] == ':':
                     length_tokens = length_tokens[1:]
                 no_close_last = (length_tokens[0] == '(')
@@ -569,17 +712,21 @@ def __Tokenize(contents):
                         if par_count == 0:
                             break
                 if par_count != 0:
-                    raise ParserError("unmatched parenthesis in %s expression" % tag)
+                    raise ParserError("unmatched parenthesis in %s expression" %
+                                      tag)
                 if len(tokens) == 0:
                     raise ParserError("invalid %s value" % tag)
                 return tokens
 
-            if ((token[:2] == "/*") and (token.count("/*") != token.count("*/"))):
+            if ((token[:2] == "/*")
+                    and (token.count("/*") != token.count("*/"))):
                 raise ParserError("multi-line comment not closed")
 
             if ((token[:2] == "/*") or (token[:2] == "//")):
+
                 def _find(word, string):
-                    return re.compile(r"[ \r\n/\*]({0})([: \r\n\*]|$)".format(word)).search(string) != None
+                    return re.compile(r"[ \r\n/\*]({0})([: \r\n\*]|$)".format(
+                        word)).search(string) != None
 
                 if _find("@stubgen", token):
                     if "@stubgen:skip" in token:
@@ -605,19 +752,25 @@ def __Tokenize(contents):
                     tagtokens.append("@EVENT")
                 if _find("@brief", token):
                     tagtokens.append("@BRIEF")
-                    desc = token[token.index("@brief") + 7:token.index("*/") if "*/" in token else None].strip()
+                    desc = token[token.index("@brief") +
+                                 7:token.index("*/") if "*/" in
+                                 token else None].strip()
                     if desc:
                         tagtokens.append(desc)
                 if _find("@details", token):
                     tagtokens.append("@DETAILS")
-                    desc = token[token.index("@details") + 9:token.index("*/") if "*/" in token else None].strip()
+                    desc = token[token.index("@details") +
+                                 9:token.index("*/") if "*/" in
+                                 token else None].strip()
                     if desc:
                         tagtokens.append(desc)
                 if _find("@param", token):
                     tagtokens.append("@PARAM")
                     idx = token.index("@param")
                     paramName = token[idx + 7:].split()[0]
-                    paramDesc = token[token.index(paramName) + len(paramName):token.index("*/") if "*/" in token else None].strip()
+                    paramDesc = token[token.index(paramName) +
+                                      len(paramName):token.index("*/") if "*/"
+                                      in token else None].strip()
                     if paramName and paramDesc:
                         tagtokens.append(paramName)
                         tagtokens.append(paramDesc)
@@ -625,7 +778,9 @@ def __Tokenize(contents):
                     tagtokens.append("@RETVAL")
                     idx = token.index("@retval")
                     errorName = token[idx + 8:].split()[0]
-                    errorDesc = token[token.index(errorName) + len(errorName):token.index("*/") if "*/" in token else None].strip()
+                    errorDesc = token[token.index(errorName) +
+                                      len(errorName):token.index("*/") if "*/"
+                                      in token else None].strip()
                     if errorName and errorDesc:
                         tagtokens.append(errorName)
                         tagtokens.append(errorDesc)
@@ -636,11 +791,11 @@ def __Tokenize(contents):
                 if _find("@interface", token):
                     tagtokens.append(__ParseLength(token, "@interface"))
                 if _find("@file", token):
-                    idx = token.index("@file:")+6
+                    idx = token.index("@file:") + 6
                     tagtokens.append("@FILE:" + token[idx:])
                     current_file = token[idx:]
                 if _find("@line", token):
-                    idx = token.index("@line:")+6
+                    idx = token.index("@line:") + 6
                     if len(tagtokens) and tagtokens[-1].startswith("@LINE:"):
                         del tagtokens[-1]
                     current_line = int(token[idx:].split()[0])
@@ -648,9 +803,10 @@ def __Tokenize(contents):
             elif len(token) > 0 and token[0] != '#' and token != "EXTERNAL":
                 tagtokens.append(token)
 
-    tagtokens.append(";") # prevent potential out-of-range errors
+    tagtokens.append(";")  # prevent potential out-of-range errors
 
     return tagtokens
+
 
 # -------------------------------------------------------------------------
 # EXPORTED FUNCTIONS
@@ -662,8 +818,10 @@ line_numbers = []
 current_line = 0
 current_file = "undefined"
 
+
 def CurrentFile():
     return current_file
+
 
 def CurrentLine():
     if i > 0:
@@ -672,6 +830,7 @@ def CurrentLine():
     else:
         # error during preprocessing
         return current_line
+
 
 # Builds a syntax tree (data structures only) of C++ source code
 def Parse(contents):
@@ -738,7 +897,7 @@ def Parse(contents):
             i += 1
 
         # Swallow template definitions
-        elif tokens[i] == "template" and tokens [i + 1] == '<':
+        elif tokens[i] == "template" and tokens[i + 1] == '<':
             s = i
             i += 1
             nest = 0
@@ -746,8 +905,8 @@ def Parse(contents):
                 if tokens[i] == ">":
                     if nest == 1:
                         break
-                    nest -=1
-                elif tokens[i] =="<":
+                    nest -= 1
+                elif tokens[i] == "<":
                     nest += 1
                 i += 1
             i += 1
@@ -757,17 +916,19 @@ def Parse(contents):
         # Parse namespace definition...
         elif tokens[i] == "namespace":
             namespace_name = ""
-            if is_valid(tokens[i + 1]): # is there a namespace name?
+            if is_valid(tokens[i + 1]):  # is there a namespace name?
                 namespace_name = tokens[i + 1]
                 i += 1
             next_block = Namespace(current_block[-1], namespace_name)
             i += 1
 
         # Parse type alias...
-        elif isinstance(current_block[-1], (Namespace, Class)) and tokens[i] == "typedef":
+        elif isinstance(current_block[-1],
+                        (Namespace, Class)) and tokens[i] == "typedef":
             j = i + 1
-            while tokens[j] != ";":  j += 1
-            typedef = Typedef(current_block[-1], tokens[i+1:j])
+            while tokens[j] != ";":
+                j += 1
+            typedef = Typedef(current_block[-1], tokens[i + 1:j])
             if event_next:
                 typedef.is_event = True
                 event_next = False
@@ -777,35 +938,47 @@ def Parse(contents):
             else:
                 i = j + 1
 
-
         # Parse "using"...
-        elif isinstance(current_block[-1], (Namespace, Class)) and tokens[i] == "using" and tokens[i + 1] != "namespace" and tokens[i + 2] == "=":
+        elif isinstance(current_block[-1],
+                        (Namespace, Class)) and tokens[i] == "using" and tokens[
+                            i + 1] != "namespace" and tokens[i + 2] == "=":
             i += 2
             j = i + 1
-            while tokens[j] != ";":  j += 1
+            while tokens[j] != ";":
+                j += 1
             # reuse typedef class but correct name accordingly
             if not current_block[-1].omit:
-                typedef = Typedef(current_block[-1], tokens[i+1:j])
+                typedef = Typedef(current_block[-1], tokens[i + 1:j])
                 if event_next:
                     typedef.is_event = True
                     event_next = False
-                typedef_id = Identifier(current_block[-1], tokens[i-1])
+                typedef_id = Identifier(current_block[-1], tokens[i - 1])
                 typedef.name = typedef_id.name
                 typedef.full_name = typedef_id.full_name
             i = j + 1
 
-        elif isinstance(current_block[-1], (Namespace, Class)) and tokens[i] == "using" and tokens[i + 1] != "namespace" and tokens[i + 2] != "=":
+        elif isinstance(current_block[-1],
+                        (Namespace, Class)) and tokens[i] == "using" and tokens[
+                            i + 1] != "namespace" and tokens[i + 2] != "=":
             if not current_block[-1].omit:
                 raise ParserError("using-declarations are not supported")
 
-        elif isinstance(current_block[-1], (Namespace, Class)) and tokens[i] == "using" and tokens[i + 1] == "namespace":
+        elif isinstance(
+                current_block[-1],
+            (Namespace,
+             Class)) and tokens[i] == "using" and tokens[i + 1] == "namespace":
             if not current_block[-1].omit:
-                raise ParserError("'using namespace' directives are not supported")
+                raise ParserError(
+                    "'using namespace' directives are not supported")
 
         # Parse class definition...
-        elif (tokens[i] == "class") or (tokens[i] == "struct") or (tokens[i] == "union"):
-            new_class = Union(current_block[-1], tokens[i + 1]) if tokens[i] == "union" else Class(current_block[-1], tokens[i + 1])
-            new_class._current_access = "private" if tokens[i] == "class" else "public"
+        elif (tokens[i] == "class") or (tokens[i] == "struct") or (
+                tokens[i] == "union"):
+            new_class = Union(current_block[-1],
+                              tokens[i + 1]) if tokens[i] == "union" else Class(
+                                  current_block[-1], tokens[i + 1])
+            new_class._current_access = "private" if tokens[
+                i] == "class" else "public"
 
             if omit_next:
                 new_class.omit = True
@@ -838,8 +1011,11 @@ def Parse(contents):
                 specifiers = []
                 while True:
                     if tokens[i + 1] in ['{', ',']:
-                        parent_ref = Type(current_block[-1], [parent_class], []) # try to find a reference to an already found type
-                        new_class.ancestors.append([parent_ref.type[0], parent_access, specifiers])
+                        parent_ref = Type(
+                            current_block[-1], [parent_class], []
+                        )  # try to find a reference to an already found type
+                        new_class.ancestors.append(
+                            [parent_ref.type[0], parent_access, specifiers])
                         parent_access = "private"
                         if tokens[i + 1] == '{':
                             break
@@ -858,18 +1034,19 @@ def Parse(contents):
                 next_block = new_class
 
         # Parse enum definition...
-        elif isinstance(current_block[-1], (Namespace, Class)) and tokens[i] == "enum":
+        elif isinstance(current_block[-1],
+                        (Namespace, Class)) and tokens[i] == "enum":
             enum_name = ""
             enum_type = "int"
             is_scoped = False
             if (tokens[i + 1] == "class") or (tokens[i + 1] == "struct"):
                 is_scoped = True
                 i += 1
-            if is_valid(tokens[i + 1]): # enum name given?
+            if is_valid(tokens[i + 1]):  # enum name given?
                 enum_name = tokens[i + 1]
                 i += 1
             if tokens[i + 1] == ':':
-                enum_type =  tokens[i + 2]
+                enum_type = tokens[i + 2]
                 i += 2
 
             new_enum = Enum(current_block[-1], enum_name, is_scoped, enum_type)
@@ -879,28 +1056,35 @@ def Parse(contents):
         # Parse class access specifier...
         elif isinstance(current_block[-1], Class) and tokens[i] == ':':
             current_block[-1]._current_access = tokens[i - 1]
-            ASSERT_ISEXPECTED(current_block[-1]._current_access, ["private", "protected", "public"])
+            ASSERT_ISEXPECTED(current_block[-1]._current_access,
+                              ["private", "protected", "public"])
             i += 1
 
         # Parse function/method definition...
-        elif isinstance(current_block[-1], (Namespace, Class)) and tokens[i] == "(":
+        elif isinstance(current_block[-1],
+                        (Namespace, Class)) and tokens[i] == "(":
             # concatenate tokens to handle operators and destructors
-            j = i - 1; k = i - 1
-            if isinstance(current_block[-1], Class) and (tokens[i - 2] == "operator"):
+            j = i - 1
+            k = i - 1
+            if isinstance(current_block[-1],
+                          Class) and (tokens[i - 2] == "operator"):
                 name = "operator" + tokens[i - 1]
-                j -= 1; k -= 1
+                j -= 1
+                k -= 1
             else:
                 name = tokens[i - 1]
                 if tokens[i - 2] == '~':
-                    name = "~" + name #dtor
-                    j -= 1; k -= 1
+                    name = "~" + name  #dtor
+                    j -= 1
+                    k -= 1
 
             # locate return value
-            while j >= min_index and tokens[j] not in  ['{', '}', ';', ':']: j -= 1
+            while j >= min_index and tokens[j] not in ['{', '}', ';', ':']:
+                j -= 1
             if not current_block[-1].omit and not omit_next:
                 ret_type = tokens[j + 1:k]
             else:
-                ret_type = [ ]
+                ret_type = []
 
             method = Method(current_block[-1], name, ret_type) if isinstance(current_block[-1], Class) \
                         else Function(current_block[-1], name, ret_type)
@@ -921,7 +1105,10 @@ def Parse(contents):
                 last_template_def = []
 
             # try to detect a function/macro call
-            function_call = not ret_type and ((name != current_block[-1].name) and (name != ("~" +current_block[-1].name)))
+            function_call = not ret_type and ((name != current_block[-1].name)
+                                              and
+                                              (name !=
+                                               ("~" + current_block[-1].name)))
 
             # parse method parameters...
             j = i
@@ -945,15 +1132,17 @@ def Parse(contents):
                     j += 1
 
                 param = tokens[i + 1:j]
-                if len(param) and not (len(param) == 1 and param[0] == "void"): # remove C-style f(void)
+                if len(param) and not (len(param) == 1 and param[0] == "void"
+                                       ):  # remove C-style f(void)
                     value = []
                     if '=' in param:
                         assignment = param.index('=')
                         param = param[0:assignment]
-                        value = param[assignment+1:]
+                        value = param[assignment + 1:]
                     if not current_block[-1].omit and not method.omit:
                         Parameter(method, param, value)
-                i = j; j += 1
+                i = j
+                j += 1
 
             if nest:
                 raise ParserError("unmatched parenthesis '('")
@@ -968,23 +1157,26 @@ def Parse(contents):
                         method.qualifiers.append(tokens[i])
                     # handle pure virtual methods
                     elif (tokens[i] == "="):
-                        if tokens[i + 1] == "0" and "virtual" in method.specifiers: # mark the virtual function as pure
-                            method.specifiers[method.specifiers.index("virtual")] = "pure-virtual"
+                        if tokens[
+                                i +
+                                1] == "0" and "virtual" in method.specifiers:  # mark the virtual function as pure
+                            method.specifiers[method.specifiers.index(
+                                "virtual")] = "pure-virtual"
                         elif tokens[i + 1] in ["default", "delete"]:
-                            method.specifiers.append(tokens[i+1])
+                            method.specifiers.append(tokens[i + 1])
                         i += 1
                     elif tokens[i] in ["override", "final", "noexcept"]:
                         method.specifiers.append(tokens[i])
                     i += 1
 
-            if function_call: # it was apparently a function call and not declaration, so remove it
+            if function_call:  # it was apparently a function call and not declaration, so remove it
                 current_block[-1].methods.pop()
             else:
                 next_block = method
 
             if tokens[i] == ';':
                 i += 1
-            elif tokens[i] == ':': # skip ctor initializers
+            elif tokens[i] == ':':  # skip ctor initializers
                 while tokens[i] != '{':
                     i += 1
 
@@ -996,28 +1188,37 @@ def Parse(contents):
         # Handle closing a compound block/composite type
         elif tokens[i] == '}':
             if isinstance(current_block[-1], Class) and (tokens[i + 1] != ';'):
-                raise ParserError("definitions following a class declaration is not supported (%s)" % current_block[-1].full_name)
+                raise ParserError(
+                    "definitions following a class declaration is not supported (%s)"
+                    % current_block[-1].full_name)
             if len(current_block) > 1:
                 current_block.pop()
             else:
                 raise ParserError("unmatched brace '{'")
             i += 1
-            next_block = Block(current_block[-1]) # new anonymous scope
+            next_block = Block(current_block[-1])  # new anonymous scope
 
         # Parse variables and member attributes
-        elif isinstance(current_block[-1], (Namespace, Class)) and tokens[i] == ';' and (is_valid(tokens[i - 1]) or tokens[i-1] == "]"):
+        elif isinstance(current_block[-1],
+                        (Namespace, Class)) and tokens[i] == ';' and (is_valid(
+                            tokens[i - 1]) or tokens[i - 1] == "]"):
             j = i - 1
-            while j >= min_index and tokens[j] not in ['{', '}', ';', ":"]: j -= 1
+            while j >= min_index and tokens[j] not in ['{', '}', ';', ":"]:
+                j -= 1
             if not current_block[-1].omit:
                 Attribute(current_block[-1], tokens[j+1:i]) if isinstance(current_block[-1], Class)  \
                             else Variable(current_block[-1], tokens[j+1:i])
             i += 1
 
         # Parse constants and member constants
-        elif isinstance(current_block[-1], (Namespace, Class)) and (tokens[i] == '=') and (tokens[i - 1] != "operator"):
-            j = i - 1; k = i + 1
-            while tokens[j] not in ['{', '}', ';', ":"]: j -= 1
-            while tokens[k] != ';': k += 1
+        elif isinstance(current_block[-1], (Namespace, Class)) and (
+                tokens[i] == '=') and (tokens[i - 1] != "operator"):
+            j = i - 1
+            k = i + 1
+            while tokens[j] not in ['{', '}', ';', ":"]:
+                j -= 1
+            while tokens[k] != ';':
+                k += 1
             if not current_block[-1].omit:
                 Attribute(current_block[-1], tokens[j+1:i], tokens[i+1:k]) if isinstance(current_block[-1], Class)  \
                             else Variable(current_block[-1], tokens[j+1:i], tokens[i+1:k])
@@ -1029,9 +1230,12 @@ def Parse(contents):
             j = i
             while True:
                 if tokens[i] in ['}', ',']:
-                    Enumerator(enum, tokens[j], tokens[j + 2: i] if tokens[j + 1] == '=' else None, enum.base_type)
-                    if tokens[i + 1] == '}' :
-                        i += 1 # handle ,} situation
+                    Enumerator(
+                        enum, tokens[j],
+                        tokens[j + 2:i] if tokens[j + 1] == '=' else None,
+                        enum.base_type)
+                    if tokens[i + 1] == '}':
+                        i += 1  # handle ,} situation
                         break
                     elif tokens[i] == '}':
                         break
@@ -1046,12 +1250,15 @@ def Parse(contents):
 
     return global_namespace
 
+
 # -------------------------------------------------------------------------
+
 
 def ParseFile(source_file):
     with open(source_file) as file:
         contents = file.read()
     return Parse(contents)
+
 
 def ParseFiles(source_files):
     contents = ""
@@ -1064,28 +1271,30 @@ def ParseFiles(source_files):
             pass
     return Parse(contents)
 
+
 # -------------------------------------------------------------------------
 
-def DumpTree(tree, ind = 0):
-    indent = ind*" "
+
+def DumpTree(tree, ind=0):
+    indent = ind * " "
 
     if isinstance(tree, (Namespace, Class)):
         print(indent + str(tree))
 
         for td in tree.typedefs:
-            print(indent + 2*" " + str(td))
+            print(indent + 2 * " " + str(td))
 
         for e in tree.enums:
-            print(indent + 2*" " + str(e))
+            print(indent + 2 * " " + str(e))
             for item in e.items:
-                print(indent + 4*" " + str(item))
+                print(indent + 4 * " " + str(item))
 
     for v in tree.vars:
-        print(indent + 2*" " + str(v))
+        print(indent + 2 * " " + str(v))
 
     if isinstance(tree, (Namespace, Class)):
         for m in tree.methods:
-           print(indent + 2*" " + str(m))
+            print(indent + 2 * " " + str(m))
 
     if isinstance(tree, (Namespace, Class)):
         for c in tree.classes:
@@ -1095,12 +1304,13 @@ def DumpTree(tree, ind = 0):
         for n in tree.namespaces:
             DumpTree(n, ind + 2)
 
+
 # -------------------------------------------------------------------------
 # entry point
 
 if __name__ == "__main__":
     tree = ParseFile(sys.argv[1])
     if isinstance(tree, Namespace):
-         DumpTree(tree)
+        DumpTree(tree)
     else:
         print(tree)

--- a/Tools/ProxyStubGenerator/Interface.py
+++ b/Tools/ProxyStubGenerator/Interface.py
@@ -1,7 +1,6 @@
-
-import CppParser
-
 #!/usr/bin/env python
+
+from . import CppParser
 
 CLASS_IUNKNOWN = "::WPEFramework::Core::IUnknown"
 

--- a/Tools/ProxyStubGenerator/Interface.py
+++ b/Tools/ProxyStubGenerator/Interface.py
@@ -4,18 +4,22 @@ from . import CppParser
 
 CLASS_IUNKNOWN = "::WPEFramework::Core::IUnknown"
 
+
 class Interface():
+
     def __init__(self, obj, iid, file):
         self.obj = obj
         self.id = iid
         self.file = file
+
 
 # Looks for interface clasess (ie. classes inheriting from Core::Unknown and specifying ID enum).
 def FindInterfaceClasses(tree, interface_namespace, source_file):
     interfaces = []
 
     def __Traverse(tree, faces):
-        if isinstance(tree, CppParser.Namespace) or isinstance(tree, CppParser.Class):
+        if isinstance(tree, CppParser.Namespace) or isinstance(
+                tree, CppParser.Class):
             for c in tree.classes:
                 if c.methods:
                     if (interface_namespace + "::") in c.full_name:
@@ -30,7 +34,9 @@ def FindInterfaceClasses(tree, interface_namespace, source_file):
                                 if not e.scoped:
                                     for item in e.items:
                                         if item.name == "ID":
-                                            faces.append(Interface(c, item.value, source_file))
+                                            faces.append(
+                                                Interface(
+                                                    c, item.value, source_file))
                                             break
                 __Traverse(c, faces)
 

--- a/Tools/ProxyStubGenerator/StubGenerator.py
+++ b/Tools/ProxyStubGenerator/StubGenerator.py
@@ -4,7 +4,11 @@
 # WPE Framework proxy stub code generator
 #
 
-import re, uuid, sys, os, argparse
+import re
+import uuid
+import sys
+import os
+import argparse
 import CppParser
 
 VERSION = "1.5.4"
@@ -35,29 +39,38 @@ IDS_DEFINITIONS_FILE = "Ids.h"
 # -------------------------------------------------------------------------
 # Logger
 
+
 class Log:
     def __init__(self):
         self.warnings = []
         self.errors = []
         self.infos = []
-    def Info(self, text, file = ""):
+
+    def Info(self, text, file=""):
         if BE_VERBOSE:
-            self.infos.append("%s: INFO: %s%s%s" % (NAME, file, ": " if file else "", text))
-            print self.infos[-1]
-    def Warn(self, text, file = ""):
+            self.infos.append("%s: INFO: %s%s%s" %
+                              (NAME, file, ": " if file else "", text))
+            print(self.infos[-1])
+
+    def Warn(self, text, file=""):
         if SHOW_WARNINGS:
-            self.warnings.append("%s: WARNING: %s%s%s" % (NAME, file, ": " if file else "", text))
-            print self.warnings[-1]
-    def Error(self, text, file = ""):
-            self.errors.append("%s: ERROR: %s%s%s" % (NAME, file, ": " if file else "", text))
-            print >> sys.stderr, self.errors[-1]
-    def Print(self, text, file = ""):
+            self.warnings.append("%s: WARNING: %s%s%s" %
+                                 (NAME, file, ": " if file else "", text))
+            print(self.warnings[-1])
+
+    def Error(self, text, file=""):
+        self.errors.append("%s: ERROR: %s%s%s" %
+                           (NAME, file, ": " if file else "", text))
+        print >> sys.stderr, self.errors[-1]
+
+    def Print(self, text, file=""):
         print("%s: %s%s%s" % (NAME, file, ": " if file else "", text))
+
     def Dump(self):
-            if self.errors or self.warnings or self.infos:
-                print ""
-                for item in self.errors + self.warnings + self.infos:
-                    print item
+        if self.errors or self.warnings or self.infos:
+            print("")
+            for item in self.errors + self.warnings + self.infos:
+                print(item)
 
 
 log = Log()
@@ -65,8 +78,10 @@ log = Log()
 # -------------------------------------------------------------------------
 # Exception classes
 
+
 class SkipFileError(RuntimeError):
     pass
+
 
 class NoInterfaceError(RuntimeError):
     pass
@@ -84,7 +99,8 @@ class TypenameError(RuntimeError):
 def CreateName(ns):
     return ns.replace("::I", "").replace("::", "")[1 if ns[0] == "I" else 0:]
 
-def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
+
+def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
     class Interface():
         def __init__(self, obj, iid, file):
             self.obj = obj
@@ -112,15 +128,19 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                                     if not e.scoped:
                                         for item in e.items:
                                             if item.name == "ID":
-                                                faces.append(Interface(c, item.value, source_file))
+                                                faces.append(
+                                                    Interface(c, item.value, source_file))
                                                 has_id = True
                                                 break
                                 if not has_id:
-                                    log.Warn("class %s does not have ID enumerator" % c.full_name, source_file)
+                                    log.Warn(
+                                        "class %s does not have ID enumerator" % c.full_name, source_file)
                             else:
-                                log.Info("class %s not does not inherit from %s" % (c.full_name, CLASS_IUNKNOWN), source_file)
+                                log.Info("class %s not does not inherit from %s" % (
+                                    c.full_name, CLASS_IUNKNOWN), source_file)
                         else:
-                            log.Info("class %s not in %s namespace" % (c.full_name, INTERFACE_NAMESPACE), source_file)
+                            log.Info("class %s not in %s namespace" % (
+                                c.full_name, INTERFACE_NAMESPACE), source_file)
 
                     __Traverse(c, faces)
 
@@ -144,13 +164,8 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
     if not interfaces:
         raise NoInterfaceError(source_file)
 
-    for iface in interfaces:
-        if iface.id < MIN_INTERFACE_ID:
-            log.Warn("invalid interface ID %s (%s) of %s - shall be at least 0x40" % (hex(iface.id) if isinstance(iface.id, (long, int)) else "?", str(iface.id), iface.obj.full_name), source_file)
-
     if scan_only:
         return interfaces
-
 
     interface_header_name = os.path.basename(source_file)
 
@@ -159,18 +174,23 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
         iface_namespace = iface_namespace_l[-1]
 
         class Emitter:
-            def __init__(self, file, size = 2):
+            def __init__(self, file, size=2):
                 self.indent = ""
                 self.size = size
                 self.file = file
+
             def IndentInc(self):
                 self.indent += ' ' * self.size
+
             def IndentDec(self):
                 self.indent = self.indent[:-INDENT_SIZE]
+
             def String(self, string):
                 file.write(string)
-            def Line(self, string = ""):
-                self.String(((self.indent + string) if len((self.indent + string).strip()) else "") + "\n")
+
+            def Line(self, string=""):
+                self.String(
+                    ((self.indent + string) if len((self.indent + string).strip()) else "") + "\n")
 
         def EmitFunctionOrder(methods):
             if methods:
@@ -187,12 +207,14 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
         emit = Emitter(file, INDENT_SIZE)
 
         emit.Line("//")
-        emit.Line("// generated automatically from \"%s\"" % interface_header_name)
+        emit.Line("// generated automatically from \"%s\"" %
+                  interface_header_name)
         emit.Line("//")
         emit.Line("// implements RPC proxy stubs for:")
         for face in interfaces:
             if not face.obj.omit:
-                emit.Line("//   - class %s" % face.obj.full_name.replace(INTERFACE_NAMESPACE+"::",""))
+                emit.Line("//   - class %s" %
+                          face.obj.full_name.replace(INTERFACE_NAMESPACE + "::", ""))
         emit.Line("//")
         emit.Line()
 
@@ -211,20 +233,23 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
         emit.Line("using namespace %s;" % iface_namespace)
         emit.Line()
 
-        announce_list = { }
+        announce_list = {}
 
         #
         # EMIT STUB CODE
         #
-        emit.Line("// -----------------------------------------------------------------")
+        emit.Line(
+            "// -----------------------------------------------------------------")
         emit.Line("// STUB")
-        emit.Line("// -----------------------------------------------------------------\n")
+        emit.Line(
+            "// -----------------------------------------------------------------\n")
 
         for iface in interfaces:
             if (iface_namespace + "::") not in iface.obj.full_name:
-                continue # inteface in other namespace
+                continue  # inteface in other namespace
 
-            iface_name = iface.obj.full_name.split(iface_namespace + "::", 1)[1]
+            iface_name = iface.obj.full_name.split(
+                iface_namespace + "::", 1)[1]
             array_name = CreateName(iface_name) + "StubMethods"
             class_name = CreateName(iface_name) + "Proxy"
             stub_name = CreateName(iface_name) + "Stub"
@@ -242,7 +267,7 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                 return ostr.strip().replace(" *", "*").replace(" &", "&")
 
             class EmitType:
-                def __init__(self, type_, cv = []):
+                def __init__(self, type_, cv=[]):
                     def _Typename(type, cv):
                         is_ref = False
                         is_ptr = False
@@ -274,35 +299,44 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                     self.oclass = type_
                     self.unexpanded = type
                     self.type = self._ExpandTypedefs(type)
-                    self.is_ref, self.is_ptr, idx, idx2, self.type = _Typename(self.type, cv)
-                    is_ref, is_ptr, typename_idx, typename_idx2, self.unexpanded = _Typename(self.unexpanded, cv)
+                    self.is_ref, self.is_ptr, idx, _, self.type = _Typename(
+                        self.type, cv)
+                    _, _, typename_idx, typename_idx2, self.unexpanded = _Typename(
+                        self.unexpanded, cv)
                     self.is_nonconstref = self.is_ref and self.type[0] != "const"
                     self.is_nonconstptr = self.is_ptr and self.type[0] != "const"
 
                     self.typename = self.unexpanded[typename_idx]
                     self.expanded_typename = self.type[idx]
-                    self.obj = self.expanded_typename if isinstance(self.expanded_typename, CppParser.Class) else None
+                    self.obj = self.expanded_typename if isinstance(
+                        self.expanded_typename, CppParser.Class) else None
                     self.str = TypeStr(self.unexpanded)
                     self.str_typename = TypeStr([self.typename])
-                    self.str_noptrref = TypeStr(self.unexpanded[:typename_idx + 1])
-                    self.str_nocvref = self.str_typename + ("*" if self.is_ptr else "")
+                    self.str_noptrref = TypeStr(
+                        self.unexpanded[:typename_idx + 1])
+                    self.str_nocvref = self.str_typename + \
+                        ("*" if self.is_ptr else "")
                     i = len(self.unexpanded) - 1
-                    while self.unexpanded[i] in ["const", "volatile", "&"]: i -= 1
+                    while self.unexpanded[i] in ["const", "volatile", "&"]:
+                        i -= 1
                     self.str_noref = TypeStr(self.unexpanded[:i + 1])
                     self.is_interface = interface or (self.is_ptr and self.obj)
 
                     self.str_rpctype = None
                     self.str_rpctype_nocv = None
-                    self.is_inputptr = self.is_ptr and (input or not self.is_nonconstptr)
+                    self.is_inputptr = self.is_ptr and (
+                        input or not self.is_nonconstptr)
                     self.is_outputptr = self.is_nonconstptr and output
-                    self.is_inputref = self.is_ref and (input or not self.is_nonconstref)
+                    self.is_inputref = self.is_ref and (
+                        input or not self.is_nonconstref)
                     self.is_outputref = self.is_nonconstref and output
                     self.is_output = self.is_outputptr or self.is_outputref
                     self.is_input = self.is_inputptr or self.is_inputref
                     self.ptr_length = length
                     self.ptr_maxlength = maxlength
                     self.ptr_interface = self.interface
-                    self.proxy = self.is_interface and (not self.is_ref or self.is_input)
+                    self.proxy = self.is_interface and (
+                        not self.is_ref or self.is_input)
                     self.origname = origname
                     self.length_constant = False
                     self.maxlength_constant = False
@@ -315,18 +349,24 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                     self.interface_expr = None
                     self.interface_type = None
                     self.length_type = "uint16_t"
-                    self.str_nocv = TypeStr(self.type[typename_idx:typename_idx2 + 1])
+                    self.str_nocv = TypeStr(
+                        self.type[typename_idx:typename_idx2 + 1])
 
                     if not self._IsValid(self.typename):
-                        raise TypenameError(type_, "unable to serialise '%s %s': undefined type '%s'" % (self.CppType(), self.origname, self.str_typename))
+                        raise TypenameError(type_, "unable to serialise '%s %s': undefined type '%s'" % (
+                            self.CppType(), self.origname, self.str_typename))
                     if not self.obj and self.is_nonconstptr and not self.is_inputptr and not self.is_outputptr and not interface:
-                        raise TypenameError(type_, "unable to serialise '%s %s': a non-const pointer requires an in/out tag" % (self.CppType(), self.origname))
+                        raise TypenameError(
+                            type_, "unable to serialise '%s %s': a non-const pointer requires an in/out tag" % (self.CppType(), self.origname))
                     if not self.obj and self.is_nonconstref and not self.is_inputref and not self.is_outputref and not interface:
-                        raise TypenameError(type_, "unable to serialise '%s %s': a non-const reference requires an in/out tag" % (self.CppType(), self.origname))
+                        raise TypenameError(
+                            type_, "unable to serialise '%s %s': a non-const reference requires an in/out tag" % (self.CppType(), self.origname))
                     if self.obj and self.is_nonconstref and self.is_nonconstptr and not self.is_inputref and not self.is_outputref and not interface:
-                        raise TypenameError(type_, "unable to serialise '%s %s': a non-const reference to pointer requires an in/out tag" % (self.CppType(), self.origname))
+                        raise TypenameError(
+                            type_, "unable to serialise '%s %s': a non-const reference to pointer requires an in/out tag" % (self.CppType(), self.origname))
                     if self.obj and self.is_nonconstref and self.is_nonconstptr and self.is_inputref and not interface:
-                        raise TypenameError(type_, "unable to serialise '%s %s': an input non-const reference to pointer parameter is not supported" % (self.CppType(), self.origname))
+                        raise TypenameError(
+                            type_, "unable to serialise '%s %s': an input non-const reference to pointer parameter is not supported" % (self.CppType(), self.origname))
 
                 def CheckRpcType(self):
                     if self.str_rpctype == None:
@@ -351,8 +391,8 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
 
                 def _IsNumeric(self, type):
                     if type in ["size_t", "time_t", "float", "uint64_t", "int64_t", "uint32_t", "int32_t", "uint16_t", "int16_t", "uint8_t", "int8_t"] \
-                        or str(type).split(" ")[-1] in ["char", "short", "long", "int", "signed", "unsigned", "double", "wchar_t"]:
-                            return True
+                            or str(type).split(" ")[-1] in ["char", "short", "long", "int", "signed", "unsigned", "double", "wchar_t"]:
+                        return True
                     return False
 
                 def _IsBoolean(self, type):
@@ -392,7 +432,8 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                         et = EmitType(self.oclass, self.ocv)
                         return et._RpcType(noref)
                     else:
-                        raise TypenameError(self.oclass, "unable to serialise type '%s'" % self.CppType())
+                        raise TypenameError(
+                            self.oclass, "unable to serialise type '%s'" % self.CppType())
 
                 def _ExpandTypedefs(self, typ):
                     expanded = []
@@ -404,18 +445,18 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                     return expanded
 
             class EmitParam(EmitType):
-                def __init__(self, type_, name = "param", cv = []):
+                def __init__(self, type_, name="param", cv=[]):
                     EmitType.__init__(self, type_, cv)
                     self.name = name
 
             class EmitRetVal(EmitParam):
-                def __init__(self, type_, name = "output", cv = []):
+                def __init__(self, type_, name="output", cv=[]):
                     EmitParam.__init__(self, type_, name, cv)
                     self.has_output = self.type and (self.type[-1] != "void")
                     self.is_output = True
 
             # Stringify a method object to full signature
-            def SignatureStr(method, parameters = None):
+            def SignatureStr(method, parameters=None):
                 params = parameters if parameters else method.vars
                 sig = ""
                 if "pure-virtual" in method.specifiers or "virtual" in method.specifiers:
@@ -431,7 +472,8 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                                 acc += " [in]"
                             elif p.is_output:
                                 acc += " [out]"
-                    sig += TypeStr(p.unexpanded if isinstance(p, EmitType) else p.type) + acc + (", " if c != len(method.vars)-1 else "")
+                    sig += TypeStr(p.unexpanded if isinstance(p, EmitType) else p.type) + \
+                        acc + (", " if c != len(method.vars) - 1 else "")
                 sig += ")"
                 for q in method.qualifiers:
                     sig += " " + q
@@ -440,7 +482,7 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                 return sig
 
             # Stringify a method object to a prototype
-            def PrototypeStr(method, parameters = None):
+            def PrototypeStr(method, parameters=None):
                 params = parameters if parameters else method.vars
                 proto = "%s %s(" % (TypeStr(method.type), method.name)
                 for c, p in enumerate(params):
@@ -453,7 +495,8 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                                 acc += " /* in */"
                             elif p.is_output:
                                 acc += " /* out */"
-                    proto += TypeStr(p.unexpanded) + acc +" param%i%s" % (c, (", " if c != len(method.vars)-1 else ""))
+                    proto += TypeStr(p.unexpanded) + acc + " param%i%s" % (c,
+                                                                           (", " if c != len(method.vars) - 1 else ""))
                 proto += ")"
                 for q in method.qualifiers:
                     proto += " " + q
@@ -463,19 +506,24 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                 return "const_cast<%s>(%s)" % (typ, identifier)
 
             if iface.obj.omit:
-                log.Print("omitted class %s" % iface.obj.full_name, source_file)
+                log.Print("omitted class %s" %
+                          iface.obj.full_name, source_file)
                 continue
 
-            emit_methods = [m for m in iface.obj.methods if "pure-virtual" in m.specifiers]
+            emit_methods = [
+                m for m in iface.obj.methods if "pure-virtual" in m.specifiers]
             if not emit_methods:
-                log.Warn("nothing emit for interface class %s" % iface.obj.full_name, source_file)
+                log.Warn("nothing emit for interface class %s" %
+                         iface.obj.full_name, source_file)
                 continue
 
             if BE_VERBOSE:
-                log.Print("Emitting stub code for interface '%s'..." % iface_name)
+                log.Print("Emitting stub code for interface '%s'..." %
+                          iface_name)
 
             # build the announce list upfront
-            announce_list[iface_name] = [class_name, array_name, stub_name, iface]
+            announce_list[iface_name] = [
+                class_name, array_name, stub_name, iface]
 
             emit.Line("//")
             emit.Line("// %s interface stub definitions" % (iface_name))
@@ -485,11 +533,11 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
 
             emit.Line()
 
-            emit.Line("%s %s[] = {" % ("ProxyStub::MethodHandler",  array_name))
+            emit.Line("%s %s[] = {" % ("ProxyStub::MethodHandler", array_name))
             emit.IndentInc()
 
             def LinkPointers(retval, parameters):
-                params = [ retval ] + parameters
+                params = [retval] + parameters
                 for c, p in enumerate(params):
                     if not p.is_length:
                         if p.is_ptr and not p.is_ref and (not p.is_interface or p.interface):
@@ -505,14 +553,15 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                                         t = None
                                         for d, q in enumerate(parameters):
                                             if q.origname == token:
-                                                t = "param"+str(d)
+                                                t = "param" + str(d)
                                                 if not sizeof_parsing:
                                                     q.is_length = True
                                                     q.is_maxlength = maxlength
                                                     q.length_name = length_name
                                                     q.length_target = target
                                                     if param_type and param_type != q.str_typename:
-                                                        raise TypenameError(p.oclass, "unable to serialise '%s': %slength variable '%s' type mismatch" % (p.origname, "max" if maxlength else "", token))
+                                                        raise TypenameError(p.oclass, "unable to serialise '%s': %slength variable '%s' type mismatch" % (
+                                                            p.origname, "max" if maxlength else "", token))
                                                     param_type = q.str_typename
                                                     has_param_ref = True
                                                     param_ref = q
@@ -524,13 +573,15 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                                                 break
                                             elif token == "sizeof":
                                                 if sizeof_parsing:
-                                                    raise TypenameError(p.oclass, "unable to serialise '%s': %slength variable has nested sizeof" % (p.origname, "max" if maxlength else ""))
+                                                    raise TypenameError(p.oclass, "unable to serialise '%s': %slength variable has nested sizeof" % (
+                                                        p.origname, "max" if maxlength else ""))
                                                 parsed.append(token)
-                                                sizeof_parsing =-True
+                                                sizeof_parsing = -True
                                             elif sizeof_parsing:
                                                 parsed.append(token)
                                             else:
-                                                raise TypenameError(p.oclass, "unable to serialise '%s': %slength variable '%s' not found" % (p.origname, "max" if maxlength else "", token))
+                                                raise TypenameError(p.oclass, "unable to serialise '%s': %slength variable '%s' not found" % (
+                                                    p.origname, "max" if maxlength else "", token))
                                         else:
                                             parsed.append(t)
                                     else:
@@ -542,7 +593,7 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                                                 if par_count == 0:
                                                     sizeof_parsing = False
                                         parsed.append(token)
-                                joined =  "".join(parsed)
+                                joined = "".join(parsed)
                                 if not param_type:
                                     param_type = "uint16_t"
                                     if not has_param_ref:
@@ -557,38 +608,45 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
 
                             if p.is_output and p.ptr_interface:
                                 p.interface_var = p.name + "_interfaceid"
-                                p.interface_expr, p.interface_type, constant, p.interface_ref = __ParseLength(p.ptr_interface, True, c-1, p.interface_var)
+                                p.interface_expr, p.interface_type, constant, p.interface_ref = __ParseLength(
+                                    p.ptr_interface, True, c - 1, p.interface_var)
                                 if constant:
-                                    raise TypenameError(p.oclass, "unable to serialise '%s': constant not allowed for interface id" % (p.origname))
+                                    raise TypenameError(
+                                        p.oclass, "unable to serialise '%s': constant not allowed for interface id" % (p.origname))
                             else:
                                 if p.is_output and p.ptr_maxlength and p.ptr_maxlength != p.ptr_length:
                                     if p.ptr_length:
                                         p.maxlength_var = p.name + "_maxlength"
-                                        p.maxlength_expr, p.length_type, p.maxlength_constant, p.length_ref = __ParseLength(p.ptr_maxlength, True, c-1, p.maxlength_var)
+                                        p.maxlength_expr, p.length_type, p.maxlength_constant, p.length_ref = __ParseLength(
+                                            p.ptr_maxlength, True, c - 1, p.maxlength_var)
                                     else:
                                         p.ptr_length = p.ptr_maxlength
                                 if p.ptr_length:
                                     p.length_var = p.name + "_length"
-                                    p.length_expr, p.length_type, p.length_constant, p.length_ref = __ParseLength(p.ptr_length, False, c-1, p.length_var)
+                                    p.length_expr, p.length_type, p.length_constant, p.length_ref = __ParseLength(
+                                        p.ptr_length, False, c - 1, p.length_var)
                             if not p.ptr_length and not p.ptr_interface:
-                                    raise TypenameError(p.oclass, "unable to serialise '%s': length variable not defined" % (p.origname))
+                                raise TypenameError(
+                                    p.oclass, "unable to serialise '%s': length variable not defined" % (p.origname))
 
             for m in emit_methods:
                 if m.omit:
-                    log.Print("omitted method %s" % iface.obj.full_name, source_file)
+                    log.Print("omitted method %s" %
+                              iface.obj.full_name, source_file)
                     emit.Line("// method omitted")
                     emit.Line("//")
                     emit.Line("")
                     continue
                 elif BE_VERBOSE:
-                     log.Print("  generating code for %s()" % m.full_name)
+                    log.Print("  generating code for %s()" % m.full_name)
 
                 proxy_count = 0
                 output_params = 0
 
                 # enumerate and prepare parameters for emitting
-                retval = EmitRetVal(m, cv = ["const"]) # force non-ptr, non-ref parameters to be const
-                params = [EmitParam(v, cv = ["const"]) for v in m.vars]
+                # force non-ptr, non-ref parameters to be const
+                retval = EmitRetVal(m, cv=["const"])
+                params = [EmitParam(v, cv=["const"]) for v in m.vars]
                 orig_params = [EmitParam(v) for v in m.vars]
                 for c, p in enumerate(params):
                     if p.proxy and p.obj:
@@ -604,11 +662,13 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                     emit.Line("//")
 
                 # emit the lambda prototype
-                emit.Line("[](Core::ProxyType<Core::IPCChannel>& channel%s, Core::ProxyType<RPC::InvokeMessage>& message) {" % (" VARIABLE_IS_NOT_USED" if not proxy_count else ""))
+                emit.Line("[](Core::ProxyType<Core::IPCChannel>& channel%s, Core::ProxyType<RPC::InvokeMessage>& message) {" % (
+                    " VARIABLE_IS_NOT_USED" if not proxy_count else ""))
                 emit.IndentInc()
 
                 if EMIT_TRACES:
-                    emit.Line('fprintf(stderr, "*** [%s stub] ENTER: %s()\\n");' % (iface.obj.full_name, m.name))
+                    emit.Line(
+                        'fprintf(stderr, "*** [%s stub] ENTER: %s()\\n");' % (iface.obj.full_name, m.name))
                     emit.Line()
 
                 emit.Line("RPC::Data::Input& input(message->Parameters());")
@@ -619,41 +679,56 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                     # emit parameter readout
                     if params:
                         emit.Line("// read parameters")
-                        emit.Line("RPC::Data::Frame::Reader reader(input.Reader());")
+                        emit.Line(
+                            "RPC::Data::Frame::Reader reader(input.Reader());")
                         for c, p in enumerate(params):
                             if (p.is_length or p.is_maxlength):
                                 if p.is_ptr:
-                                    raise TypenameError(p.oclass, "unsupported: '%s' length variable is a pointer" % p.origname)
+                                    raise TypenameError(
+                                        p.oclass, "unsupported: '%s' length variable is a pointer" % p.origname)
                                 elif p.obj:
-                                    raise TypenameError(p.oclass, "'%s' length variable is an object" % p.origname)
+                                    raise TypenameError(
+                                        p.oclass, "'%s' length variable is an object" % p.origname)
 
                             # if parameter is passed by value or by reference, then try to  decompose it
                             if not p.is_ptr and not p.CheckRpcType():
                                 if p.obj:
-                                    emit.Line("// (decompose %s)" % p.str_typename)
-                                    emit.Line("%s %s;" % (p.str_typename, p.name))
+                                    emit.Line("// (decompose %s)" %
+                                              p.str_typename)
+                                    emit.Line("%s %s;" %
+                                              (p.str_typename, p.name))
                                     # TODO: make this recursive
                                     if p.obj.vars:
                                         for attr in p.obj.vars:
-                                            emit.Line("param%i.%s = reader.%s();" % (c, attr.name, EmitParam(attr).RpcTypeNoCV()))
+                                            emit.Line("param%i.%s = reader.%s();" % (
+                                                c, attr.name, EmitParam(attr).RpcTypeNoCV()))
                                     else:
-                                        raise TypenameError(m, "method '%s': unable to decompose parameter '%s': non-POD type" % (m.name, p.str_typename))
+                                        raise TypenameError(
+                                            m, "method '%s': unable to decompose parameter '%s': non-POD type" % (m.name, p.str_typename))
                                 elif not p.RpcType():
-                                    raise TypenameError(m, "method '%s': unable to decompose parameter '%s': unknown type" % (m.name, p.str_typename))
+                                    raise TypenameError(m, "method '%s': unable to decompose parameter '%s': unknown type" % (
+                                        m.name, p.str_typename))
                             else:
                                 if p.is_ptr and not p.obj and not p.is_ref and p.length_type == "void":
-                                    emit.Line("%s %s = %s; // storage" % (p.str_typename, p.name, NULLPTR))
+                                    emit.Line("%s %s = %s; // storage" %
+                                              (p.str_typename, p.name, NULLPTR))
                                 elif p.is_ptr and not p.obj and not p.is_ref:
                                     if p.is_input:
-                                        emit.Line("const %s %s = %s;" % (p.str_nocvref, p.name, NULLPTR))
-                                        emit.Line("%s %s_length = reader.Lock%s(%s);" % (p.length_type, p.name, p.RpcTypeNoCV(), p.name))
-                                        emit.Line("reader.UnlockBuffer(%s_length);" % p.name)
+                                        emit.Line("const %s %s = %s;" % (
+                                            p.str_nocvref, p.name, NULLPTR))
+                                        emit.Line("%s %s_length = reader.Lock%s(%s);" % (
+                                            p.length_type, p.name, p.RpcTypeNoCV(), p.name))
+                                        emit.Line(
+                                            "reader.UnlockBuffer(%s_length);" % p.name)
                                 elif p.is_ref and not p.is_input:
-                                    emit.Line("%s %s{}; // storage" % (p.str_nocvref, p.name))
+                                    emit.Line("%s %s{}; // storage" %
+                                              (p.str_nocvref, p.name))
                                     if p.is_length or p.is_maxlength:
-                                        raise TypenameError(p.oclass, "'%s' is defined as a length variable but is write-only" % p.origname)
+                                        raise TypenameError(
+                                            p.oclass, "'%s' is defined as a length variable but is write-only" % p.origname)
                                 elif not p.is_length or p.is_maxlength or not params[p.length_target].is_input:
-                                    emit.Line("%s %s = reader.%s();" % (p.str_nocvref if p.proxy else p.str_noref, p.length_name if p.is_length else p.name, p.RpcTypeNoCV()))
+                                    emit.Line("%s %s = reader.%s();" % (
+                                        p.str_nocvref if p.proxy else p.str_noref, p.length_name if p.is_length else p.name, p.RpcTypeNoCV()))
                                 if p.is_length:
                                     p.name = p.length_name
 
@@ -668,42 +743,57 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                                         emit.Line()
                                         if p.is_input:
                                             if p.maxlength_var:
-                                                emit.Line("// allocate receive buffer if necessary")
+                                                emit.Line(
+                                                    "// allocate receive buffer if necessary")
                                             oldname = p.name
                                             p.name = p.name + "_buffer"
                                         elif not p.is_input:
-                                            emit.Line("// allocate receive buffer")
-                                        emit.Line("%s %s{};" % (p.str_nocvref, p.name))
+                                            emit.Line(
+                                                "// allocate receive buffer")
+                                        emit.Line("%s %s{};" %
+                                                  (p.str_nocvref, p.name))
                                         length_var = p.maxlength_var if p.maxlength_var else p.length_var
                                         if p.length_constant:
-                                            emit.Line("const %s %s = %s;" % (p.length_type, p.length_var, p.length_expr))
+                                            emit.Line("const %s %s = %s;" % (
+                                                p.length_type, p.length_var, p.length_expr))
                                         if p.is_input:
                                             if p.maxlength_var:
                                                 # input/output and maxlength defined
-                                                emit.Line("%s = const_cast<%s>(%s);" % (p.name, p.str_nocvref, oldname))
-                                                emit.Line("if (%s > %s) {" % (p.maxlength_var, p.length_var))
+                                                emit.Line("%s = const_cast<%s>(%s);" % (
+                                                    p.name, p.str_nocvref, oldname))
+                                                emit.Line("if (%s > %s) {" % (
+                                                    p.maxlength_var, p.length_var))
                                                 emit.IndentInc()
-                                                if  p.length_type not in ["char", "short", "int8_t", "uint8_t", "int16_t", "uint16_t"]:
-                                                    emit.Line("ASSERT((%s < 0x10000) && \"Buffer too large\");" % length_var)
-                                                emit.Line("%s = static_cast<%s>(ALLOCA(%s));" % (p.name, p.str_nocvref, length_var))
-                                                emit.Line("ASSERT(%s != nullptr);" % p.name)
+                                                if p.length_type not in ["char", "short", "int8_t", "uint8_t", "int16_t", "uint16_t"]:
+                                                    emit.Line(
+                                                        "ASSERT((%s < 0x10000) && \"Buffer too large\");" % length_var)
+                                                emit.Line("%s = static_cast<%s>(ALLOCA(%s));" % (
+                                                    p.name, p.str_nocvref, length_var))
+                                                emit.Line(
+                                                    "ASSERT(%s != nullptr);" % p.name)
                                             else:
                                                 # is input/output but maxlength not defined
-                                                emit.Line("%s = const_cast<%s>(%s); // reuse the input buffer" % (p.name, p.str_nocvref, oldname))
+                                                emit.Line(
+                                                    "%s = const_cast<%s>(%s); // reuse the input buffer" % (p.name, p.str_nocvref, oldname))
                                         else:
                                             # is output-only
                                             if not p.length_constant:
-                                                emit.Line("if (%s != 0) {" % p.length_var)
+                                                emit.Line(
+                                                    "if (%s != 0) {" % p.length_var)
                                                 emit.IndentInc()
-                                            if  p.length_type not in ["char", "short", "int8_t", "uint8_t", "int16_t", "uint16_t"]:
-                                                emit.Line("ASSERT((%s < 0x10000) && \"Buffer length too big\");" % length_var)
-                                            emit.Line("%s = static_cast<%s>(ALLOCA(%s));" % (p.name, p.str_nocvref, length_var))
-                                            emit.Line("ASSERT(%s != nullptr);" % p.name)
+                                            if p.length_type not in ["char", "short", "int8_t", "uint8_t", "int16_t", "uint16_t"]:
+                                                emit.Line(
+                                                    "ASSERT((%s < 0x10000) && \"Buffer length too big\");" % length_var)
+                                            emit.Line("%s = static_cast<%s>(ALLOCA(%s));" % (
+                                                p.name, p.str_nocvref, length_var))
+                                            emit.Line(
+                                                "ASSERT(%s != nullptr);" % p.name)
                                             if not p.length_constant:
                                                 emit.IndentDec()
                                                 emit.Line("}")
                                         if p.is_input and p.maxlength_var:
-                                            emit.Line("::memcpy(%s, %s, %s);" % (p.name, oldname, p.length_var))
+                                            emit.Line("::memcpy(%s, %s, %s);" % (
+                                                p.name, oldname, p.length_var))
                                             emit.IndentDec()
                                             emit.Line("}")
 
@@ -711,24 +801,31 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                         for p in params:
                             if p.proxy:
                                 proxy_name = p.name + "_proxy"
-                                emit.Line("%s %s = %s;" % (p.str_nocvref, proxy_name, NULLPTR))
-                                emit.Line("ProxyStub::UnknownProxy* %s_inst = %s;" % (proxy_name, NULLPTR))
-                                emit.Line("if (%s != %s) {" % (p.name, NULLPTR))
+                                emit.Line("%s %s = %s;" %
+                                          (p.str_nocvref, proxy_name, NULLPTR))
+                                emit.Line(
+                                    "ProxyStub::UnknownProxy* %s_inst = %s;" % (proxy_name, NULLPTR))
+                                emit.Line("if (%s != %s) {" % (
+                                    p.name, NULLPTR))
                                 emit.IndentInc()
                                 # create proxy
                                 emit.Line("%s_inst = RPC::Administrator::Instance().ProxyInstance(channel, %s, %s::ID, false, %s::ID, true);"
-                                                % (proxy_name, p.name, p.str_typename, p.str_typename))
-                                emit.Line("if (%s_inst != %s) {" % (proxy_name, NULLPTR))
+                                          % (proxy_name, p.name, p.str_typename, p.str_typename))
+                                emit.Line("if (%s_inst != %s) {" % (
+                                    proxy_name, NULLPTR))
                                 emit.IndentInc()
-                                emit.Line("%s = %s_inst->QueryInterface<%s>();" %(proxy_name, proxy_name, p.str_typename))
+                                emit.Line("%s = %s_inst->QueryInterface<%s>();" %
+                                          (proxy_name, proxy_name, p.str_typename))
                                 emit.IndentDec()
                                 emit.Line("}")
                                 emit.Line()
                                 emit.Line("ASSERT((%s != %s) && \"Failed to get instance of %s proxy\");"
-                                                % (proxy_name, NULLPTR, p.str_typename))
-                                emit.Line("if (%s == %s) {" % (proxy_name, NULLPTR))
+                                          % (proxy_name, NULLPTR, p.str_typename))
+                                emit.Line("if (%s == %s) {" % (
+                                    proxy_name, NULLPTR))
                                 emit.IndentInc()
-                                emit.Line("TRACE_L1(\"Failed to get instance of %s proxy\");" % p.str_typename)
+                                emit.Line(
+                                    "TRACE_L1(\"Failed to get instance of %s proxy\");" % p.str_typename)
                                 emit.IndentDec()
                                 emit.Line("}")
                                 emit.IndentDec()
@@ -736,59 +833,76 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                         emit.Line()
 
                     if (retval.has_output or output_params) and proxy_count:
-                        emit.Line("// write return value%s" %("s" if (int(retval.has_output) + output_params > 1) else ""))
-                        emit.Line("RPC::Data::Frame::Writer writer(message->Response().Writer());")
+                        emit.Line("// write return value%s" %
+                                  ("s" if (int(retval.has_output) + output_params > 1) else ""))
+                        emit.Line(
+                            "RPC::Data::Frame::Writer writer(message->Response().Writer());")
                         emit.Line()
 
                     # emit code to validate the proxy(s)
                     if proxy_count:
-                        if_proxy_line = "if " + ("(" if proxy_count > 1 else "")
+                        if_proxy_line = "if " + \
+                            ("(" if proxy_count > 1 else "")
                         c = 0
                         for p in params:
                             if p.proxy:
-                                if_proxy_line += "((" + p.name + " == nullptr) || (" + p.name + "_proxy != %s" % NULLPTR + "))" + (" && " if (c != proxy_count -1) else "")
+                                if_proxy_line += "((" + p.name + " == nullptr) || (" + p.name + "_proxy != %s" % NULLPTR + "))" + (
+                                    " && " if (c != proxy_count - 1) else "")
                                 c += 1
-                        if_proxy_line += (")" if proxy_count > 1 else "") + " {"
+                        if_proxy_line += (")" if proxy_count >
+                                          1 else "") + " {"
                         emit.Line(if_proxy_line)
                         emit.IndentInc()
 
                     # emit function call
                     emit.Line("// call implementation")
-                    emit.Line("%s* implementation = input.Implementation<%s>();" % ((" ".join(m.qualifiers) + " " + iface_name).strip(), iface_name))
-                    emit.Line("ASSERT((implementation != %s) && \"Null %s implementation pointer\");" % (NULLPTR, iface_name))
+                    emit.Line("%s* implementation = input.Implementation<%s>();" %
+                              ((" ".join(m.qualifiers) + " " + iface_name).strip(), iface_name))
+                    emit.Line("ASSERT((implementation != %s) && \"Null %s implementation pointer\");" % (
+                        NULLPTR, iface_name))
                     call = ""
                     if retval.has_output:
                         call += "%s %s = " % (retval.str_noref, retval.name)
                     call += "implementation->%s(" % m.name
                     for c, p in enumerate(params):
-                        call += "%s%s%s%s" % ("&" if p.length_type == "void" else "", p.name, ("_proxy" if p.proxy else ""), (", " if c < len(params) - 1 else ""))
+                        call += "%s%s%s%s" % ("&" if p.length_type == "void" else "", p.name,
+                                              ("_proxy" if p.proxy else ""), (", " if c < len(params) - 1 else ""))
                     call += ");"
                     emit.Line(call)
 
                     if (retval.has_output or output_params) and not proxy_count:
                         emit.Line()
-                        emit.Line("// write return value%s" %("s" if (int(retval.has_output) + output_params > 1) else ""))
-                        emit.Line("RPC::Data::Frame::Writer writer(message->Response().Writer());")
+                        emit.Line("// write return value%s" %
+                                  ("s" if (int(retval.has_output) + output_params > 1) else ""))
+                        emit.Line(
+                            "RPC::Data::Frame::Writer writer(message->Response().Writer());")
 
                     # forward the output value
                     if retval.has_output:
                         if not retval.is_ptr and not retval.CheckRpcType():
                             if retval.obj:
-                                emit.Line("// (decompose %s)" % retval.str_typename)
+                                emit.Line("// (decompose %s)" %
+                                          retval.str_typename)
                                 if retval.obj.vars:
                                     for attr in retval.obj.vars:
-                                        emit.Line("writer.%s(output.%s);" % (EmitParam(attr).RpcTypeNoCV(), attr.name))
+                                        emit.Line("writer.%s(output.%s);" % (
+                                            EmitParam(attr).RpcTypeNoCV(), attr.name))
                                 else:
-                                    raise TypenameError(m, "method '%s': unable to decompose parameter type '%s': non-POD type" % (m.name, retval.str_typename))
+                                    raise TypenameError(
+                                        m, "method '%s': unable to decompose parameter type '%s': non-POD type" % (m.name, retval.str_typename))
                             elif not retval.RpcType():
-                                raise TypenameError(m, "method '%s': unable to decompose parameter '%s': unknown type" % (m.name, retval.str_typename))
+                                raise TypenameError(m, "method '%s': unable to decompose parameter '%s': unknown type" % (
+                                    m.name, retval.str_typename))
                         else:
-                            emit.Line("writer.%s(%s);" % (retval.RpcType(), retval.name))
+                            emit.Line("writer.%s(%s);" %
+                                      (retval.RpcType(), retval.name))
                             if retval.is_interface:
                                 if retval.typename == "void":
-                                    emit.Line("RPC::Administrator::Instance().RegisterInterface(channel, %s, %s);" % (retval.name, retval.interface_ref.length_name))
+                                    emit.Line("RPC::Administrator::Instance().RegisterInterface(channel, %s, %s);" % (
+                                        retval.name, retval.interface_ref.length_name))
                                 else:
-                                    emit.Line("RPC::Administrator::Instance().RegisterInterface(channel, %s);" % retval.name)
+                                    emit.Line(
+                                        "RPC::Administrator::Instance().RegisterInterface(channel, %s);" % retval.name)
 
                     if output_params:
                         for p in params:
@@ -797,20 +911,26 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                                     # temporarily remove the pointer
                                     temp = p.oclass
                                     temp.type.remove("*")
-                                    emit.Line("writer.%s(%s);" % (EmitType(temp).RpcType(), p.name))
+                                    emit.Line("writer.%s(%s);" %
+                                              (EmitType(temp).RpcType(), p.name))
                                 else:
-                                    if p.length_var and p.length_ref and  p.length_ref.is_output:
-                                        emit.Line("writer.%s(%s);" % (p.length_ref.RpcType(), p.length_var))
-                                    emit.Line("if ((%s != %s) && (%s != 0)) {" % (p.name, NULLPTR, p.length_var))
+                                    if p.length_var and p.length_ref and p.length_ref.is_output:
+                                        emit.Line("writer.%s(%s);" % (
+                                            p.length_ref.RpcType(), p.length_var))
+                                    emit.Line("if ((%s != %s) && (%s != 0)) {" % (
+                                        p.name, NULLPTR, p.length_var))
                                     emit.IndentInc()
-                                    emit.Line("writer.%s(%s, %s);" % (p.RpcType(), p.length_var if p.length_var else p.maxlength_var, p.name))
+                                    emit.Line("writer.%s(%s, %s);" % (
+                                        p.RpcType(), p.length_var if p.length_var else p.maxlength_var, p.name))
                                     emit.IndentDec()
                                     emit.Line("}")
                             elif p.is_nonconstref:
                                 if not p.is_length:
-                                    emit.Line("writer.%s(%s);" % (p.RpcType(), p.name))
+                                    emit.Line("writer.%s(%s);" %
+                                              (p.RpcType(), p.name))
                                 if p.is_interface:
-                                    emit.Line("RPC::Administrator::Instance().RegisterInterface(channel, %s);" % p.name)
+                                    emit.Line(
+                                        "RPC::Administrator::Instance().RegisterInterface(channel, %s);" % p.name)
 
                     if proxy_count:
                         emit.IndentDec()
@@ -820,7 +940,8 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                             emit.Line()
                             emit.IndentInc()
                             emit.Line("// return error code")
-                            emit.Line("writer.Number<const %s>(Core::ERROR_RPC_CALL_FAILED);" % retval.typename)
+                            emit.Line(
+                                "writer.Number<const %s>(Core::ERROR_RPC_CALL_FAILED);" % retval.typename)
                             emit.IndentDec()
                             emit.Line("}")
                         else:
@@ -830,23 +951,28 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                         emit.Line()
                         for p in params:
                             if p.proxy:
-                                emit.Line("if (%s_proxy_inst != %s) {" %(p.name, NULLPTR))
+                                emit.Line("if (%s_proxy_inst != %s) {" % (
+                                    p.name, NULLPTR))
                                 emit.IndentInc()
-                                emit.Line("RPC::Administrator::Instance().Release(%s_proxy_inst, message->Response());" % p.name)
+                                emit.Line(
+                                    "RPC::Administrator::Instance().Release(%s_proxy_inst, message->Response());" % p.name)
                                 emit.IndentDec()
                                 emit.Line("}")
 
                 else:
                     log.Print("stubbed method %s" % m.full_name, source_file)
                     if params:
-                        emit.Line("RPC::Data::Frame::Reader reader(input.Reader());")
+                        emit.Line(
+                            "RPC::Data::Frame::Reader reader(input.Reader());")
                     if retval.has_output:
-                        emit.Line("RPC::Data::Frame::Writer writer(message->Response().Writer());")
+                        emit.Line(
+                            "RPC::Data::Frame::Writer writer(message->Response().Writer());")
                     emit.Line("// TODO")
 
                 if EMIT_TRACES:
                     emit.Line()
-                    emit.Line('fprintf(stderr, "*** [%s stub] EXIT: %s()\\n");' % (iface.obj.full_name, m.name))
+                    emit.Line(
+                        'fprintf(stderr, "*** [%s stub] EXIT: %s()\\n");' % (iface.obj.full_name, m.name))
 
                 emit.IndentDec()
                 emit.Line("},\n")
@@ -858,44 +984,52 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
         #
         # EMIT PROXY CODE
         #
-        emit.Line("// -----------------------------------------------------------------")
+        emit.Line(
+            "// -----------------------------------------------------------------")
         emit.Line("// PROXY")
-        emit.Line("// -----------------------------------------------------------------\n")
+        emit.Line(
+            "// -----------------------------------------------------------------\n")
 
         for iface in interfaces:
             if (iface_namespace + "::") not in iface.obj.full_name:
                 continue
-            iface_name = iface.obj.full_name.split(INTERFACE_NAMESPACE + "::", 1)[1]
+            iface_name = iface.obj.full_name.split(
+                INTERFACE_NAMESPACE + "::", 1)[1]
             if not iface_name in announce_list:
                 continue
 
             class_name = announce_list[iface_name][0]
 
-            emit_methods = [m for m in iface.obj.methods if "pure-virtual" in m.specifiers]
+            emit_methods = [
+                m for m in iface.obj.methods if "pure-virtual" in m.specifiers]
             if not emit_methods:
                 continue
 
             if BE_VERBOSE:
-                log.Print("Emitting proxy code for interface '%s'..." % iface_name)
+                log.Print("Emitting proxy code for interface '%s'..." %
+                          iface_name)
 
             emit.Line("//")
             emit.Line("// %s interface proxy definitions" % (iface_name))
             emit.Line("//")
 
-            #emit stub order comment
+            # emit stub order comment
             if EMIT_COMMENT_WITH_STUB_ORDER:
                 EmitFunctionOrder(emit_methods)
 
             emit.Line()
 
             # emit proxy class definition
-            emit.Line("class %s%s : public ProxyStub::UnknownProxyType<%s> {" % (class_name, " final" if not USE_OLD_CPP else " /* final */", iface_name))
+            emit.Line("class %s%s : public ProxyStub::UnknownProxyType<%s> {" % (
+                class_name, " final" if not USE_OLD_CPP else " /* final */", iface_name))
             emit.Line("public:")
             emit.IndentInc()
 
             # emit constructor
-            emit.Line("%s(const Core::ProxyType<Core::IPCChannel>& channel, void* implementation, const bool otherSideInformed)" % class_name)
-            emit.Line("    : BaseClass(channel, implementation, otherSideInformed)")
+            emit.Line(
+                "%s(const Core::ProxyType<Core::IPCChannel>& channel, void* implementation, const bool otherSideInformed)" % class_name)
+            emit.Line(
+                "    : BaseClass(channel, implementation, otherSideInformed)")
             emit.Line("{")
             emit.Line("}")
             emit.Line()
@@ -911,8 +1045,8 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
             for m in emit_methods:
                 input_params = 0
                 # enumerate and prepare parameters for emitting
-                retval = EmitRetVal(m, cv = ["const"])
-                params = [EmitParam(v, cv = ["const"]) for v in m.vars]
+                retval = EmitRetVal(m, cv=["const"])
+                params = [EmitParam(v, cv=["const"]) for v in m.vars]
                 orig_params = [EmitParam(v) for v in m.vars]
 
                 LinkPointers(retval, params)
@@ -922,7 +1056,8 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                     if (not p.is_nonconstref and not p.is_nonconstptr) or (p.is_input and not p.is_length) or (p.is_ptr and p.obj) or (p.is_length and not params[p.length_target].is_input):
                         input_params += 1
 
-                method_line = PrototypeStr(m, orig_params) + (" override" if not USE_OLD_CPP else " /* override */")
+                method_line = PrototypeStr(
+                    m, orig_params) + (" override" if not USE_OLD_CPP else " /* override */")
 
                 if m.omit:
                     emit.Line("// %s" % method_line)
@@ -936,10 +1071,12 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                 emit.Line("{")
                 emit.IndentInc()
                 if EMIT_TRACES:
-                    emit.Line('fprintf(stderr, "*** [%s proxy] ENTER: %s()\\n");' % (iface.obj.full_name, m.name))
+                    emit.Line(
+                        'fprintf(stderr, "*** [%s proxy] ENTER: %s()\\n");' % (iface.obj.full_name, m.name))
                     emit.Line()
 
-                emit.Line("IPCMessage newMessage(BaseClass::Message(%i));" % count)
+                emit.Line(
+                    "IPCMessage newMessage(BaseClass::Message(%i));" % count)
                 emit.Line()
                 count += 1
                 proxy_params = 0
@@ -948,36 +1085,43 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                 if not m.stub:
                     if input_params:
                         emit.Line("// write parameters")
-                        emit.Line("RPC::Data::Frame::Writer writer(newMessage->Parameters().Writer());")
+                        emit.Line(
+                            "RPC::Data::Frame::Writer writer(newMessage->Parameters().Writer());")
 
                         for c, p in enumerate(params):
                             if not p.is_ptr and not p.CheckRpcType():
                                 if p.obj:
                                     if p.obj.vars:
-                                        emit.Line("// (decompose %s)" % p.str_typename)
+                                        emit.Line("// (decompose %s)" %
+                                                  p.str_typename)
                                         for attr in p.obj.vars:
-                                            emit.Line("writer.%s(param%i.%s);" % (EmitParam(attr).RpcTypeNoCV(), c, attr.name))
+                                            emit.Line("writer.%s(param%i.%s);" % (
+                                                EmitParam(attr).RpcTypeNoCV(), c, attr.name))
                                     else:
-                                        raise TypenameError(m, "method '%s': unable to decompose parameter '%s': non-POD type" % (m.name, p.str_typename))
+                                        raise TypenameError(
+                                            m, "method '%s': unable to decompose parameter '%s': non-POD type" % (m.name, p.str_typename))
                                 elif not p.RpcType():
-                                    raise TypenameError(m, "method '%s': unable to decompose parameter '%s': unknown type" % (m.name, p.str_typename))
+                                    raise TypenameError(m, "method '%s': unable to decompose parameter '%s': unknown type" % (
+                                        m.name, p.str_typename))
                             else:
                                 if p.is_ptr and p.obj:
                                     proxy_params += 1
                                 if not p.obj and p.is_ptr:
                                     if p.is_input:
-                                        emit.Line("writer.%s(%s, param%i);" % (p.RpcType(), p.length_expr, c))
+                                        emit.Line("writer.%s(%s, param%i);" % (
+                                            p.RpcType(), p.length_expr, c))
                                 elif not p.is_input and p.is_nonconstref and p.is_nonconstptr:
                                     pass
                                 elif (not p.is_length or not params[p.length_target].is_input or p.is_maxlength) and (p.is_input or (not p.is_nonconstref and not p.is_nonconstptr) or p.obj):
-                                    emit.Line("writer.%s(param%i);" % (p.RpcType(), c))
+                                    emit.Line("writer.%s(param%i);" %
+                                              (p.RpcType(), c))
                         emit.Line()
 
                     for c, p in enumerate(params):
                         if not p.is_ptr and not p.CheckRpcType():
                             pass
                         else:
-                            if (p.is_nonconstref and p.obj) or (not p.obj and p.is_outputptr) or ( p.is_nonconstref and not p.is_length):
+                            if (p.is_nonconstref and p.obj) or (not p.obj and p.is_outputptr) or (p.is_nonconstref and not p.is_length):
                                 output_params += 1
 
                     retval_has_proxy = retval.has_output and retval.is_interface
@@ -987,55 +1131,74 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                         default = "{}"
                         if isinstance(retval.typename, (CppParser.Typedef, CppParser.Enum)):
                             default = " = static_cast<%s>(~0)" % retval.str_nocvref
-                        emit.Line("%s %s%s%s;" % (retval.str_nocvref, retval.name, "_proxy" if retval_has_proxy else "", default))
-                        if any(x in ["uint32_t"] for x in str(retval.typename).split()): # assume it's a status code
-                            emit.Line("if ((%s = Invoke(newMessage)) == Core::ERROR_NONE) {" % retval.name)
+                        emit.Line("%s %s%s%s;" % (
+                            retval.str_nocvref, retval.name, "_proxy" if retval_has_proxy else "", default))
+                        # assume it's a status code
+                        if any(x in ["uint32_t"] for x in str(retval.typename).split()):
+                            emit.Line(
+                                "if ((%s = Invoke(newMessage)) == Core::ERROR_NONE) {" % retval.name)
                         else:
-                            emit.Line("if (Invoke(newMessage) == Core::ERROR_NONE) {")
+                            emit.Line(
+                                "if (Invoke(newMessage) == Core::ERROR_NONE) {")
                         emit.IndentInc()
                     elif proxy_params + output_params > 0:
-                        emit.Line("if (Invoke(newMessage) == Core::ERROR_NONE) {")
+                        emit.Line(
+                            "if (Invoke(newMessage) == Core::ERROR_NONE) {")
                         emit.IndentInc()
                     else:
                         emit.Line("Invoke(newMessage);")
 
                     if retval.has_output or (output_params > 0) or (proxy_params > 0):
-                        emit.Line("// read return value%s" % ("s" if (int(retval.has_output) + output_params > 1) else ""))
-                        emit.Line("RPC::Data::Frame::Reader reader(newMessage->Response().Reader());")
+                        emit.Line("// read return value%s" %
+                                  ("s" if (int(retval.has_output) + output_params > 1) else ""))
+                        emit.Line(
+                            "RPC::Data::Frame::Reader reader(newMessage->Response().Reader());")
 
                     if retval.has_output:
                         if retval.is_interface:
                             if retval.obj:
-                                emit.Line("%s_proxy = reinterpret_cast<%s>(Interface(reader.Number<void*>(), %s::ID));" % (retval.name, retval.str_nocvref, retval.str_typename))
+                                emit.Line("%s_proxy = reinterpret_cast<%s>(Interface(reader.Number<void*>(), %s::ID));" % (
+                                    retval.name, retval.str_nocvref, retval.str_typename))
                             else:
-                                emit.Line("%s_proxy = Interface(reader.Number<void*>(),%s);" % (retval.name, retval.interface_expr))
+                                emit.Line("%s_proxy = Interface(reader.Number<void*>(),%s);" %
+                                          (retval.name, retval.interface_expr))
                         else:
                             if not retval.is_ptr and not retval.CheckRpcType():
                                 if retval.obj:
-                                    emit.Line("// (decompose %s)" % retval.str_typename)
+                                    emit.Line("// (decompose %s)" %
+                                              retval.str_typename)
                                     if retval.obj.vars:
                                         for attr in retval.obj.vars:
-                                            emit.Line("%s.%s = reader.%s();" % (retval.name, attr.name, EmitParam(attr, cv = ["const"]).RpcTypeNoCV()))
+                                            emit.Line("%s.%s = reader.%s();" % (
+                                                retval.name, attr.name, EmitParam(attr, cv=["const"]).RpcTypeNoCV()))
                                     else:
-                                        raise TypenameError(m, "method '%s': unable to decompose return value '%s': non-POD type" % (m.name, retval.str_typename))
+                                        raise TypenameError(
+                                            m, "method '%s': unable to decompose return value '%s': non-POD type" % (m.name, retval.str_typename))
                                 elif not retval.RpcType():
-                                    raise TypenameError(m, "method '%s': unable to decompose '%s': unknown type" % (m.name, retval.str_typename))
+                                    raise TypenameError(m, "method '%s': unable to decompose '%s': unknown type" % (
+                                        m.name, retval.str_typename))
                             else:
-                                emit.Line("%s = reader.%s();" % (retval.name, retval.RpcTypeNoCV()))
+                                emit.Line("%s = reader.%s();" %
+                                          (retval.name, retval.RpcTypeNoCV()))
 
                     for p in params:
                         if p.is_nonconstref and p.is_interface:
-                            emit.Line("%s = reinterpret_cast<%s>(Interface(reader.Number<void*>(), %s::ID));" % (p.name, p.str_nocvref, p.str_typename))
+                            emit.Line("%s = reinterpret_cast<%s>(Interface(reader.Number<void*>(), %s::ID));" % (
+                                p.name, p.str_nocvref, p.str_typename))
                         elif not p.obj and p.is_outputptr:
                             if p.length_var and p.length_ref and p.length_ref.is_output:
-                                emit.Line("%s = reader.%s();" % (p.length_ref.name, p.length_ref.RpcType()))
-                            emit.Line("if ((%s != %s) && (%s != 0)) {" % (p.name, NULLPTR, p.length_expr))
+                                emit.Line("%s = reader.%s();" % (
+                                    p.length_ref.name, p.length_ref.RpcType()))
+                            emit.Line("if ((%s != %s) && (%s != 0)) {" % (
+                                p.name, NULLPTR, p.length_expr))
                             emit.IndentInc()
-                            emit.Line("reader.%s(%s, %s);" % (p.RpcType(), p.length_expr, p.name))
+                            emit.Line("reader.%s(%s, %s);" %
+                                      (p.RpcType(), p.length_expr, p.name))
                             emit.IndentDec()
                             emit.Line("}")
                         elif p.is_nonconstref and not p.is_length:
-                            emit.Line("%s = reader.%s();" % (p.name, p.RpcTypeNoCV()))
+                            emit.Line("%s = reader.%s();" %
+                                      (p.name, p.RpcTypeNoCV()))
 
                     # emit Complete() only if there were interfaces passed
                     if proxy_params > 0:
@@ -1043,27 +1206,30 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
                             emit.Line()
                         emit.Line("Complete(reader);")
 
-
                     if retval.has_output or (proxy_params + output_params > 0):
                         emit.IndentDec()
                         emit.Line("}")
 
                     if EMIT_TRACES:
                         emit.Line()
-                        emit.Line('fprintf(stderr, "*** [%s proxy] EXIT: %s()\\n");' % (iface.obj.full_name, m.name))
+                        emit.Line(
+                            'fprintf(stderr, "*** [%s proxy] EXIT: %s()\\n");' % (iface.obj.full_name, m.name))
 
                     if retval.has_output:
                         emit.Line()
-                        emit.Line("return %s%s;" % (retval.name, "_proxy" if retval_has_proxy else ""))
+                        emit.Line("return %s%s;" % (
+                            retval.name, "_proxy" if retval_has_proxy else ""))
 
                 else:
                     if m.vars:
-                        emit.Line("RPC::Data::Frame::Writer writer(newMessage->Parameters().Writer());")
+                        emit.Line(
+                            "RPC::Data::Frame::Writer writer(newMessage->Parameters().Writer());")
                         emit.Line("// TODO")
                         emit.Line()
 
                     if retval.has_output:
-                        emit.Line("RPC::Data::Frame::Reader reader(newMessage->Response().Reader());")
+                        emit.Line(
+                            "RPC::Data::Frame::Reader reader(newMessage->Response().Reader());")
                         emit.Line("// TODO")
                         emit.Line()
 
@@ -1089,9 +1255,11 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
         #
         # EMIT REGISTRATION CODE
         #
-        emit.Line("// -----------------------------------------------------------------")
+        emit.Line(
+            "// -----------------------------------------------------------------")
         emit.Line("// REGISTRATION")
-        emit.Line("// -----------------------------------------------------------------")
+        emit.Line(
+            "// -----------------------------------------------------------------")
         emit.Line()
         emit.Line("namespace {")
         emit.IndentInc()
@@ -1099,8 +1267,9 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
         if announce_list:
             emit.Line()
 
-        for key, val in announce_list.iteritems():
-            emit.Line("typedef ProxyStub::UnknownStubType<%s, %s> %s;" % (key, val[1], val[2]))
+        for key, val in announce_list.items():
+            emit.Line("typedef ProxyStub::UnknownStubType<%s, %s> %s;" %
+                      (key, val[1], val[2]))
 
         emit.Line()
 
@@ -1111,8 +1280,9 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
         emit.Line("{")
         emit.IndentInc()
 
-        for key, val in announce_list.iteritems():
-            emit.Line("RPC::Administrator::Instance().Announce<%s, %s, %s>();" % (key, val[0], val[2]))
+        for key, val in announce_list.items():
+            emit.Line("RPC::Administrator::Instance().Announce<%s, %s, %s>();" % (
+                key, val[0], val[2]))
 
         emit.IndentDec()
         emit.Line("}")
@@ -1126,29 +1296,43 @@ def GenerateStubs(output_file, source_file, defaults = "", scan_only = False):
         emit.IndentDec()
         emit.Line("} // namespace %s" % STUB_NAMESPACE.split("::")[-1])
         emit.Line()
-        emit.Line("}") # // namespace %s" % STUB_NAMESPACE.split("::")[-1])
+        emit.Line("}")  # // namespace %s" % STUB_NAMESPACE.split("::")[-1])
 
     return interfaces
 
 # -------------------------------------------------------------------------
 # entry point
 
+
 if __name__ == "__main__":
-    argparser = argparse.ArgumentParser(description='Generate proxy stub code out of interface header files.', formatter_class=argparse.RawTextHelpFormatter )
-    argparser.add_argument('path', nargs="*", help="Interface file(s) or a directory(ies) with interface files")
-    argparser.add_argument("--help-tags", dest="help_tags", action="store_true", default=False, help="show help on supported source code tags and exit")
-    argparser.add_argument("--version", dest="show_version", action="store_true", default=False, help="display version")
-    argparser.add_argument("-i", dest="extra_include",  metavar="FILE", action="store", default=DEFAULT_DEFINITIONS_FILE, help="include a C++ header file (default: include '%s')" % DEFAULT_DEFINITIONS_FILE)
-    argparser.add_argument("--namespace", dest="if_namespace", metavar="NS", type=str, action="store", default=INTERFACE_NAMESPACE, help="set namespace to look for interfaces in (default: %s)" % INTERFACE_NAMESPACE)
-    argparser.add_argument("--indent", dest="indent_size", metavar="SIZE", type=int, action="store", default=INDENT_SIZE, help="set code indentation in spaces (default: %i)" % INDENT_SIZE)
-    argparser.add_argument("--traces", dest="traces", action="store_true", default=False, help="emit traces in generated proxy/stub code (default: no extra traces)")
-    argparser.add_argument("--old-cpp", dest="old_cpp", action="store_true", default=False, help="do not emit some C++11 keywords (default: emit modern C++ code)")
-    argparser.add_argument("--no-warnings", dest="no_warnings", action="store_true", default=False, help="suppress all warnings (default: show warnings)")
-    argparser.add_argument("--keep", dest="keep_incomplete", action="store_true", default=False, help="keep incomplete files (default: remove partially generated files)")
-    argparser.add_argument("--verbose", dest="verbose", action="store_true", default=False, help="enable verbose output (default: verbose output disabled)")
+    argparser = argparse.ArgumentParser(
+        description='Generate proxy stub code out of interface header files.', formatter_class=argparse.RawTextHelpFormatter)
+    argparser.add_argument(
+        'path', nargs="*", help="Interface file(s) or a directory(ies) with interface files")
+    argparser.add_argument("--help-tags", dest="help_tags", action="store_true",
+                           default=False, help="show help on supported source code tags and exit")
+    argparser.add_argument("--version", dest="show_version",
+                           action="store_true", default=False, help="display version")
+    argparser.add_argument("-i", dest="extra_include", metavar="FILE", action="store", default=DEFAULT_DEFINITIONS_FILE,
+                           help="include a C++ header file (default: include '%s')" % DEFAULT_DEFINITIONS_FILE)
+    argparser.add_argument("--namespace", dest="if_namespace", metavar="NS", type=str, action="store",
+                           default=INTERFACE_NAMESPACE, help="set namespace to look for interfaces in (default: %s)" % INTERFACE_NAMESPACE)
+    argparser.add_argument("--indent", dest="indent_size", metavar="SIZE", type=int, action="store",
+                           default=INDENT_SIZE, help="set code indentation in spaces (default: %i)" % INDENT_SIZE)
+    argparser.add_argument("--traces", dest="traces", action="store_true", default=False,
+                           help="emit traces in generated proxy/stub code (default: no extra traces)")
+    argparser.add_argument("--old-cpp", dest="old_cpp", action="store_true", default=False,
+                           help="do not emit some C++11 keywords (default: emit modern C++ code)")
+    argparser.add_argument("--no-warnings", dest="no_warnings", action="store_true",
+                           default=False, help="suppress all warnings (default: show warnings)")
+    argparser.add_argument("--keep", dest="keep_incomplete", action="store_true", default=False,
+                           help="keep incomplete files (default: remove partially generated files)")
+    argparser.add_argument("--verbose", dest="verbose", action="store_true",
+                           default=False, help="enable verbose output (default: verbose output disabled)")
     args = argparser.parse_args(sys.argv[1:])
     DEFAULT_DEFINITIONS_FILE = args.extra_include
-    INDENT_SIZE = args.indent_size if (args.indent_size > 0 and args.indent_size < 32) else INDENT_SIZE
+    INDENT_SIZE = args.indent_size if (
+        args.indent_size > 0 and args.indent_size < 32) else INDENT_SIZE
     USE_OLD_CPP = args.old_cpp
     SHOW_WARNINGS = not args.no_warnings
     BE_VERBOSE = args.verbose
@@ -1161,24 +1345,25 @@ if __name__ == "__main__":
         INTERFACE_NAMESPACE = "::" + INTERFACE_NAMESPACE
 
     if args.help_tags:
-        print "The following special tags are supported:"
-        print "   @stubgen:skip     - skip parsing of the rest of the file"
-        print "   @stubgen:omit     - omit generating code for the next item (class or method)"
-        print "   @stubgen:stub     - generate empty stub for the next item (class or method)"
-        print "For non-const pointer and reference method/function parameters:"
-        print "   @in               - denotes an input parameter"
-        print "   @out              - denotes an output parameter"
-        print "   @inout            - denotes an input/output parameter (equivalent of @in @out)"
-        print "   @length:<expr>    - specifies a buffer length value (a constant, a parameter name or a math expression)"
-        print "   @maxlength:<expr> - specifies a maximum buffer length value (a constant, a parameter name or a math expression),"
-        print "                       if not specified @length is used as maximum length, use round parenthesis for expressions,"
-        print "                       e.g.: @length:bufferSize @length:(width*height*4)"
-        print ""
-        print "The tags shall be placed inside comments."
+        print("The following special tags are supported:")
+        print("   @stubgen:skip     - skip parsing of the rest of the file")
+        print("   @stubgen:omit     - omit generating code for the next item (class or method)")
+        print(
+            "   @stubgen:stub     - generate empty stub for the next item (class or method)")
+        print("For non-const pointer and reference method/function parameters:")
+        print("   @in               - denotes an input parameter")
+        print("   @out              - denotes an output parameter")
+        print("   @inout            - denotes an input/output parameter (equivalent of @in @out)")
+        print("   @length:<expr>    - specifies a buffer length value (a constant, a parameter name or a math expression)")
+        print("   @maxlength:<expr> - specifies a maximum buffer length value (a constant, a parameter name or a math expression),")
+        print("                       if not specified @length is used as maximum length, use round parenthesis for expressions,")
+        print("                       e.g.: @length:bufferSize @length:(width*height*4)")
+        print("")
+        print("The tags shall be placed inside comments.")
         sys.exit()
 
     if args.show_version:
-        print "Version: " + VERSION
+        print("Version: " + VERSION)
         sys.exit()
 
     if not args.path:
@@ -1187,7 +1372,8 @@ if __name__ == "__main__":
         interface_files = []
         for elem in args.path:
             if os.path.isdir(elem):
-                interface_files += [os.path.join(elem, f) for f in os.listdir(elem) if (os.path.isfile(os.path.join(elem, f)) and re.match("I.*\\.h", f) and f != IDS_DEFINITIONS_FILE)]
+                interface_files += [os.path.join(elem, f) for f in os.listdir(elem) if (os.path.isfile(
+                    os.path.join(elem, f)) and re.match("I.*\\.h", f) and f != IDS_DEFINITIONS_FILE)]
             elif os.path.isfile(elem):
                 interface_files += [elem]
             else:
@@ -1198,9 +1384,11 @@ if __name__ == "__main__":
         if interface_files:
             for source_file in interface_files:
                 try:
-                    output_file = os.path.join(os.path.dirname(source_file), PROXYSTUB_CPP_NAME % CreateName(os.path.basename(source_file)).split(".", 1)[0])
+                    output_file = os.path.join(os.path.dirname(source_file), PROXYSTUB_CPP_NAME % CreateName(
+                        os.path.basename(source_file)).split(".", 1)[0])
 
-                    output = GenerateStubs(output_file, source_file, os.path.join(os.path.dirname(os.path.realpath(__file__)), DEFAULT_DEFINITIONS_FILE), scan_only)
+                    output = GenerateStubs(output_file, source_file, os.path.join(os.path.dirname(
+                        os.path.realpath(__file__)), DEFAULT_DEFINITIONS_FILE), scan_only)
                     faces += output
 
                     log.Print("created file '%s'" % output_file)
@@ -1208,13 +1396,14 @@ if __name__ == "__main__":
                     # dump interfaces if only scanning
                     for f in sorted(output, key=lambda x: x.id):
                         if scan_only:
-                            print f.id, f.obj.full_name
+                            print(f.id, f.obj.full_name)
 
                 except SkipFileError as err:
                     log.Print("skipped file '%s'" % err)
                     skipped.append(source_file)
                 except NoInterfaceError as err:
-                    log.Info("no interface classes found in %s" %( INTERFACE_NAMESPACE), source_file)
+                    log.Info("no interface classes found in %s" %
+                             (INTERFACE_NAMESPACE), source_file)
                 except TypenameError as err:
                     log.Error(err)
                     if not keep_incomplete and os.path.isfile(output_file):
@@ -1223,29 +1412,31 @@ if __name__ == "__main__":
                     log.Error(err)
 
             if scan_only:
-                print "\nInterface dump:"
+                print("\nInterface dump:")
 
             sorted_faces = sorted(faces, key=lambda x: x.id)
             for i, f in enumerate(sorted_faces):
-                if isinstance(f.id, (long, int)):
+                if isinstance(f.id, int):
                     if scan_only:
                         if i and sorted_faces[i - 1].id < f.id - 1:
-                            print "..."
-                        print "%s (%s) - '%s'" % (hex(f.id) if isinstance(f.id, (int, long)) else "?", str(f.id), f.obj.full_name)
+                            print("...")
+                        print("%s (%s) - '%s'" % (hex(f.id) if isinstance(f.id,
+                                                                          int) else "?", str(f.id), f.obj.full_name))
                     if i and sorted_faces[i - 1].id == f.id:
-                        log.Warn("duplicate interface ID %s (%s) of %s" % (hex(f.id) if isinstance(f.id, (int, long)) else "?", str(f.id), f.obj.full_name), f.file)
+                        log.Warn("duplicate interface ID %s (%s) of %s" % (hex(f.id) if isinstance(
+                            f.id, int) else "?", str(f.id), f.obj.full_name), f.file)
                 else:
-                    log.Info("can't evaluate interface ID \"%s\" of %s" % (str(f.id), f.obj.full_name), f.file)
-
+                    log.Info("can't evaluate interface ID \"%s\" of %s" %
+                             (str(f.id), f.obj.full_name), f.file)
 
             if len(interface_files) > 1 and BE_VERBOSE:
-                print ""
+                print("")
 
-            log.Print(("all done; %i file%s processed" % (len(interface_files) - len(skipped), "s" if len(interface_files) - len(skipped) > 1 else "")) + \
-                ((" (%i file%s skipped)" % (len(skipped), "s" if len(skipped) > 1 else "")) if skipped else "") + \
-                ("; %i interface%s parsed:" % (len(faces), "s" if len(faces) > 1 else "")) + \
-                ((" %i error%s" % (len(log.errors), "s" if len(log.errors) > 1 else "")) if log.errors else " no errors") + \
-                ((" (%i warning%s)" % (len(log.warnings), "s" if len(log.warnings) > 1 else "")) if log.warnings else ""))
+            log.Print(("all done; %i file%s processed" % (len(interface_files) - len(skipped), "s" if len(interface_files) - len(skipped) > 1 else "")) +
+                      ((" (%i file%s skipped)" % (len(skipped), "s" if len(skipped) > 1 else "")) if skipped else "") +
+                      ("; %i interface%s parsed:" % (len(faces), "s" if len(faces) > 1 else "")) +
+                      ((" %i error%s" % (len(log.errors), "s" if len(log.errors) > 1 else "")) if log.errors else " no errors") +
+                      ((" (%i warning%s)" % (len(log.warnings), "s" if len(log.warnings) > 1 else "")) if log.warnings else ""))
         else:
             log.Print("Nothing to do")
 

--- a/Tools/ProxyStubGenerator/StubGenerator.py
+++ b/Tools/ProxyStubGenerator/StubGenerator.py
@@ -41,6 +41,7 @@ IDS_DEFINITIONS_FILE = "Ids.h"
 
 
 class Log:
+
     def __init__(self):
         self.warnings = []
         self.errors = []
@@ -88,6 +89,7 @@ class NoInterfaceError(RuntimeError):
 
 
 class TypenameError(RuntimeError):
+
     def __init__(self, type, msg):
         msg = "%s(%s): %s" % (type.parser_file, type.parser_line, msg)
         super(TypenameError, self).__init__(msg)
@@ -96,12 +98,15 @@ class TypenameError(RuntimeError):
 
 # -------------------------------------------------------------------------
 
+
 def CreateName(ns):
     return ns.replace("::I", "").replace("::", "")[1 if ns[0] == "I" else 0:]
 
 
 def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
+
     class Interface():
+
         def __init__(self, obj, iid, file):
             self.obj = obj
             self.id = iid
@@ -112,7 +117,8 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
         interfaces = []
 
         def __Traverse(tree, faces):
-            if isinstance(tree, CppParser.Namespace) or isinstance(tree, CppParser.Class):
+            if isinstance(tree, CppParser.Namespace) or isinstance(
+                    tree, CppParser.Class):
                 for c in tree.classes:
                     if c.methods:
                         if (INTERFACE_NAMESPACE + "::") in c.full_name:
@@ -129,18 +135,23 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                                         for item in e.items:
                                             if item.name == "ID":
                                                 faces.append(
-                                                    Interface(c, item.value, source_file))
+                                                    Interface(
+                                                        c, item.value,
+                                                        source_file))
                                                 has_id = True
                                                 break
                                 if not has_id:
                                     log.Warn(
-                                        "class %s does not have ID enumerator" % c.full_name, source_file)
+                                        "class %s does not have ID enumerator" %
+                                        c.full_name, source_file)
                             else:
-                                log.Info("class %s not does not inherit from %s" % (
-                                    c.full_name, CLASS_IUNKNOWN), source_file)
+                                log.Info(
+                                    "class %s not does not inherit from %s" %
+                                    (c.full_name, CLASS_IUNKNOWN), source_file)
                         else:
-                            log.Info("class %s not in %s namespace" % (
-                                c.full_name, INTERFACE_NAMESPACE), source_file)
+                            log.Info(
+                                "class %s not in %s namespace" %
+                                (c.full_name, INTERFACE_NAMESPACE), source_file)
 
                     __Traverse(c, faces)
 
@@ -174,6 +185,7 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
         iface_namespace = iface_namespace_l[-1]
 
         class Emitter:
+
             def __init__(self, file, size=2):
                 self.indent = ""
                 self.size = size
@@ -189,8 +201,8 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                 file.write(string)
 
             def Line(self, string=""):
-                self.String(
-                    ((self.indent + string) if len((self.indent + string).strip()) else "") + "\n")
+                self.String(((self.indent + string) if len(
+                    (self.indent + string).strip()) else "") + "\n")
 
         def EmitFunctionOrder(methods):
             if methods:
@@ -213,8 +225,9 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
         emit.Line("// implements RPC proxy stubs for:")
         for face in interfaces:
             if not face.obj.omit:
-                emit.Line("//   - class %s" %
-                          face.obj.full_name.replace(INTERFACE_NAMESPACE + "::", ""))
+                emit.Line(
+                    "//   - class %s" %
+                    face.obj.full_name.replace(INTERFACE_NAMESPACE + "::", ""))
         emit.Line("//")
         emit.Line()
 
@@ -239,17 +252,18 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
         # EMIT STUB CODE
         #
         emit.Line(
-            "// -----------------------------------------------------------------")
+            "// -----------------------------------------------------------------"
+        )
         emit.Line("// STUB")
         emit.Line(
-            "// -----------------------------------------------------------------\n")
+            "// -----------------------------------------------------------------\n"
+        )
 
         for iface in interfaces:
             if (iface_namespace + "::") not in iface.obj.full_name:
                 continue  # inteface in other namespace
 
-            iface_name = iface.obj.full_name.split(
-                iface_namespace + "::", 1)[1]
+            iface_name = iface.obj.full_name.split(iface_namespace + "::", 1)[1]
             array_name = CreateName(iface_name) + "StubMethods"
             class_name = CreateName(iface_name) + "Proxy"
             stub_name = CreateName(iface_name) + "Stub"
@@ -258,7 +272,8 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
             def TypeStr(type):
                 ostr = ""
                 for t in type:
-                    strt = t.Name() if isinstance(t, CppParser.Identifier) else str(t)
+                    strt = t.Name() if isinstance(
+                        t, CppParser.Identifier) else str(t)
                     # cut the scope to current namespace
                     for n in iface_namespace_l:
                         if (n + "::") in strt:
@@ -267,7 +282,9 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                 return ostr.strip().replace(" *", "*").replace(" &", "&")
 
             class EmitType:
+
                 def __init__(self, type_, cv=[]):
+
                     def _Typename(type, cv):
                         is_ref = False
                         is_ptr = False
@@ -282,7 +299,10 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                             is_ptr = True
                         while self.type[typename_idx] in ["*", "&"]:
                             typename_idx -= 1
-                        if cv and not is_ptr and not is_ref and (type[-1] != "void") and (type[0] not in ["const", "volatile"]):
+                        if cv and not is_ptr and not is_ref and (
+                                type[-1] != "void") and (type[0] not in [
+                                    "const", "volatile"
+                                ]):
                             type = cv + type
                             typename_idx += len(cv)
                         return is_ref, is_ptr, typename_idx, typename_idx2, type
@@ -312,8 +332,8 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                         self.expanded_typename, CppParser.Class) else None
                     self.str = TypeStr(self.unexpanded)
                     self.str_typename = TypeStr([self.typename])
-                    self.str_noptrref = TypeStr(
-                        self.unexpanded[:typename_idx + 1])
+                    self.str_noptrref = TypeStr(self.unexpanded[:typename_idx +
+                                                                1])
                     self.str_nocvref = self.str_typename + \
                         ("*" if self.is_ptr else "")
                     i = len(self.unexpanded) - 1
@@ -324,19 +344,19 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
 
                     self.str_rpctype = None
                     self.str_rpctype_nocv = None
-                    self.is_inputptr = self.is_ptr and (
-                        input or not self.is_nonconstptr)
+                    self.is_inputptr = self.is_ptr and (input or
+                                                        not self.is_nonconstptr)
                     self.is_outputptr = self.is_nonconstptr and output
-                    self.is_inputref = self.is_ref and (
-                        input or not self.is_nonconstref)
+                    self.is_inputref = self.is_ref and (input or
+                                                        not self.is_nonconstref)
                     self.is_outputref = self.is_nonconstref and output
                     self.is_output = self.is_outputptr or self.is_outputref
                     self.is_input = self.is_inputptr or self.is_inputref
                     self.ptr_length = length
                     self.ptr_maxlength = maxlength
                     self.ptr_interface = self.interface
-                    self.proxy = self.is_interface and (
-                        not self.is_ref or self.is_input)
+                    self.proxy = self.is_interface and (not self.is_ref
+                                                        or self.is_input)
                     self.origname = origname
                     self.length_constant = False
                     self.maxlength_constant = False
@@ -353,20 +373,30 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                         self.type[typename_idx:typename_idx2 + 1])
 
                     if not self._IsValid(self.typename):
-                        raise TypenameError(type_, "unable to serialise '%s %s': undefined type '%s'" % (
-                            self.CppType(), self.origname, self.str_typename))
+                        raise TypenameError(
+                            type_,
+                            "unable to serialise '%s %s': undefined type '%s'" %
+                            (self.CppType(), self.origname, self.str_typename))
                     if not self.obj and self.is_nonconstptr and not self.is_inputptr and not self.is_outputptr and not interface:
                         raise TypenameError(
-                            type_, "unable to serialise '%s %s': a non-const pointer requires an in/out tag" % (self.CppType(), self.origname))
+                            type_,
+                            "unable to serialise '%s %s': a non-const pointer requires an in/out tag"
+                            % (self.CppType(), self.origname))
                     if not self.obj and self.is_nonconstref and not self.is_inputref and not self.is_outputref and not interface:
                         raise TypenameError(
-                            type_, "unable to serialise '%s %s': a non-const reference requires an in/out tag" % (self.CppType(), self.origname))
+                            type_,
+                            "unable to serialise '%s %s': a non-const reference requires an in/out tag"
+                            % (self.CppType(), self.origname))
                     if self.obj and self.is_nonconstref and self.is_nonconstptr and not self.is_inputref and not self.is_outputref and not interface:
                         raise TypenameError(
-                            type_, "unable to serialise '%s %s': a non-const reference to pointer requires an in/out tag" % (self.CppType(), self.origname))
+                            type_,
+                            "unable to serialise '%s %s': a non-const reference to pointer requires an in/out tag"
+                            % (self.CppType(), self.origname))
                     if self.obj and self.is_nonconstref and self.is_nonconstptr and self.is_inputref and not interface:
                         raise TypenameError(
-                            type_, "unable to serialise '%s %s': an input non-const reference to pointer parameter is not supported" % (self.CppType(), self.origname))
+                            type_,
+                            "unable to serialise '%s %s': an input non-const reference to pointer parameter is not supported"
+                            % (self.CppType(), self.origname))
 
                 def CheckRpcType(self):
                     if self.str_rpctype == None:
@@ -411,7 +441,10 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                     return isinstance(type, CppParser.Class)
 
                 def _IsValid(self, type):
-                    return self._IsNumeric(type) or self._IsBoolean(type) or self._IsString(type) or self._IsEnum(type) or self._IsTypedef(type) or self._IsObject(type) or type == "void"
+                    return self._IsNumeric(type) or self._IsBoolean(
+                        type) or self._IsString(type) or self._IsEnum(
+                            type) or self._IsTypedef(type) or self._IsObject(
+                                type) or type == "void"
 
                 # Converts a C++ type to RPC types
                 def _RpcType(self, noref):
@@ -433,7 +466,8 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                         return et._RpcType(noref)
                     else:
                         raise TypenameError(
-                            self.oclass, "unable to serialise type '%s'" % self.CppType())
+                            self.oclass,
+                            "unable to serialise type '%s'" % self.CppType())
 
                 def _ExpandTypedefs(self, typ):
                     expanded = []
@@ -445,11 +479,13 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                     return expanded
 
             class EmitParam(EmitType):
+
                 def __init__(self, type_, name="param", cv=[]):
                     EmitType.__init__(self, type_, cv)
                     self.name = name
 
             class EmitRetVal(EmitParam):
+
                 def __init__(self, type_, name="output", cv=[]):
                     EmitParam.__init__(self, type_, name, cv)
                     self.has_output = self.type and (self.type[-1] != "void")
@@ -495,8 +531,8 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                                 acc += " /* in */"
                             elif p.is_output:
                                 acc += " /* out */"
-                    proto += TypeStr(p.unexpanded) + acc + " param%i%s" % (c,
-                                                                           (", " if c != len(method.vars) - 1 else ""))
+                    proto += TypeStr(p.unexpanded) + acc + " param%i%s" % (c, (
+                        ", " if c != len(method.vars) - 1 else ""))
                 proto += ")"
                 for q in method.qualifiers:
                     proto += " " + q
@@ -506,15 +542,16 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                 return "const_cast<%s>(%s)" % (typ, identifier)
 
             if iface.obj.omit:
-                log.Print("omitted class %s" %
-                          iface.obj.full_name, source_file)
+                log.Print("omitted class %s" % iface.obj.full_name, source_file)
                 continue
 
             emit_methods = [
-                m for m in iface.obj.methods if "pure-virtual" in m.specifiers]
+                m for m in iface.obj.methods if "pure-virtual" in m.specifiers
+            ]
             if not emit_methods:
-                log.Warn("nothing emit for interface class %s" %
-                         iface.obj.full_name, source_file)
+                log.Warn(
+                    "nothing emit for interface class %s" % iface.obj.full_name,
+                    source_file)
                 continue
 
             if BE_VERBOSE:
@@ -523,7 +560,8 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
 
             # build the announce list upfront
             announce_list[iface_name] = [
-                class_name, array_name, stub_name, iface]
+                class_name, array_name, stub_name, iface
+            ]
 
             emit.Line("//")
             emit.Line("// %s interface stub definitions" % (iface_name))
@@ -540,8 +578,11 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                 params = [retval] + parameters
                 for c, p in enumerate(params):
                     if not p.is_length:
-                        if p.is_ptr and not p.is_ref and (not p.is_interface or p.interface):
-                            def __ParseLength(length, maxlength, target, length_name):
+                        if p.is_ptr and not p.is_ref and (not p.is_interface
+                                                          or p.interface):
+
+                            def __ParseLength(length, maxlength, target,
+                                              length_name):
                                 parsed = []
                                 has_param_ref = False
                                 sizeof_parsing = False
@@ -560,8 +601,13 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                                                     q.length_name = length_name
                                                     q.length_target = target
                                                     if param_type and param_type != q.str_typename:
-                                                        raise TypenameError(p.oclass, "unable to serialise '%s': %slength variable '%s' type mismatch" % (
-                                                            p.origname, "max" if maxlength else "", token))
+                                                        raise TypenameError(
+                                                            p.oclass,
+                                                            "unable to serialise '%s': %slength variable '%s' type mismatch"
+                                                            %
+                                                            (p.origname,
+                                                             "max" if maxlength
+                                                             else "", token))
                                                     param_type = q.str_typename
                                                     has_param_ref = True
                                                     param_ref = q
@@ -573,15 +619,22 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                                                 break
                                             elif token == "sizeof":
                                                 if sizeof_parsing:
-                                                    raise TypenameError(p.oclass, "unable to serialise '%s': %slength variable has nested sizeof" % (
-                                                        p.origname, "max" if maxlength else ""))
+                                                    raise TypenameError(
+                                                        p.oclass,
+                                                        "unable to serialise '%s': %slength variable has nested sizeof"
+                                                        % (p.origname, "max" if
+                                                           maxlength else ""))
                                                 parsed.append(token)
                                                 sizeof_parsing = -True
                                             elif sizeof_parsing:
                                                 parsed.append(token)
                                             else:
-                                                raise TypenameError(p.oclass, "unable to serialise '%s': %slength variable '%s' not found" % (
-                                                    p.origname, "max" if maxlength else "", token))
+                                                raise TypenameError(
+                                                    p.oclass,
+                                                    "unable to serialise '%s': %slength variable '%s' not found"
+                                                    %
+                                                    (p.origname, "max" if
+                                                     maxlength else "", token))
                                         else:
                                             parsed.append(t)
                                     else:
@@ -609,30 +662,37 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                             if p.is_output and p.ptr_interface:
                                 p.interface_var = p.name + "_interfaceid"
                                 p.interface_expr, p.interface_type, constant, p.interface_ref = __ParseLength(
-                                    p.ptr_interface, True, c - 1, p.interface_var)
+                                    p.ptr_interface, True, c - 1,
+                                    p.interface_var)
                                 if constant:
                                     raise TypenameError(
-                                        p.oclass, "unable to serialise '%s': constant not allowed for interface id" % (p.origname))
+                                        p.oclass,
+                                        "unable to serialise '%s': constant not allowed for interface id"
+                                        % (p.origname))
                             else:
                                 if p.is_output and p.ptr_maxlength and p.ptr_maxlength != p.ptr_length:
                                     if p.ptr_length:
                                         p.maxlength_var = p.name + "_maxlength"
                                         p.maxlength_expr, p.length_type, p.maxlength_constant, p.length_ref = __ParseLength(
-                                            p.ptr_maxlength, True, c - 1, p.maxlength_var)
+                                            p.ptr_maxlength, True, c - 1,
+                                            p.maxlength_var)
                                     else:
                                         p.ptr_length = p.ptr_maxlength
                                 if p.ptr_length:
                                     p.length_var = p.name + "_length"
                                     p.length_expr, p.length_type, p.length_constant, p.length_ref = __ParseLength(
-                                        p.ptr_length, False, c - 1, p.length_var)
+                                        p.ptr_length, False, c - 1,
+                                        p.length_var)
                             if not p.ptr_length and not p.ptr_interface:
                                 raise TypenameError(
-                                    p.oclass, "unable to serialise '%s': length variable not defined" % (p.origname))
+                                    p.oclass,
+                                    "unable to serialise '%s': length variable not defined"
+                                    % (p.origname))
 
             for m in emit_methods:
                 if m.omit:
-                    log.Print("omitted method %s" %
-                              iface.obj.full_name, source_file)
+                    log.Print("omitted method %s" % iface.obj.full_name,
+                              source_file)
                     emit.Line("// method omitted")
                     emit.Line("//")
                     emit.Line("")
@@ -662,13 +722,15 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                     emit.Line("//")
 
                 # emit the lambda prototype
-                emit.Line("[](Core::ProxyType<Core::IPCChannel>& channel%s, Core::ProxyType<RPC::InvokeMessage>& message) {" % (
-                    " VARIABLE_IS_NOT_USED" if not proxy_count else ""))
+                emit.Line(
+                    "[](Core::ProxyType<Core::IPCChannel>& channel%s, Core::ProxyType<RPC::InvokeMessage>& message) {"
+                    % (" VARIABLE_IS_NOT_USED" if not proxy_count else ""))
                 emit.IndentInc()
 
                 if EMIT_TRACES:
                     emit.Line(
-                        'fprintf(stderr, "*** [%s stub] ENTER: %s()\\n");' % (iface.obj.full_name, m.name))
+                        'fprintf(stderr, "*** [%s stub] ENTER: %s()\\n");' %
+                        (iface.obj.full_name, m.name))
                     emit.Line()
 
                 emit.Line("RPC::Data::Input& input(message->Parameters());")
@@ -685,10 +747,14 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                             if (p.is_length or p.is_maxlength):
                                 if p.is_ptr:
                                     raise TypenameError(
-                                        p.oclass, "unsupported: '%s' length variable is a pointer" % p.origname)
+                                        p.oclass,
+                                        "unsupported: '%s' length variable is a pointer"
+                                        % p.origname)
                                 elif p.obj:
                                     raise TypenameError(
-                                        p.oclass, "'%s' length variable is an object" % p.origname)
+                                        p.oclass,
+                                        "'%s' length variable is an object" %
+                                        p.origname)
 
                             # if parameter is passed by value or by reference, then try to  decompose it
                             if not p.is_ptr and not p.CheckRpcType():
@@ -700,35 +766,51 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                                     # TODO: make this recursive
                                     if p.obj.vars:
                                         for attr in p.obj.vars:
-                                            emit.Line("param%i.%s = reader.%s();" % (
-                                                c, attr.name, EmitParam(attr).RpcTypeNoCV()))
+                                            emit.Line(
+                                                "param%i.%s = reader.%s();" %
+                                                (c, attr.name,
+                                                 EmitParam(attr).RpcTypeNoCV()))
                                     else:
                                         raise TypenameError(
-                                            m, "method '%s': unable to decompose parameter '%s': non-POD type" % (m.name, p.str_typename))
+                                            m,
+                                            "method '%s': unable to decompose parameter '%s': non-POD type"
+                                            % (m.name, p.str_typename))
                                 elif not p.RpcType():
-                                    raise TypenameError(m, "method '%s': unable to decompose parameter '%s': unknown type" % (
-                                        m.name, p.str_typename))
+                                    raise TypenameError(
+                                        m,
+                                        "method '%s': unable to decompose parameter '%s': unknown type"
+                                        % (m.name, p.str_typename))
                             else:
                                 if p.is_ptr and not p.obj and not p.is_ref and p.length_type == "void":
                                     emit.Line("%s %s = %s; // storage" %
                                               (p.str_typename, p.name, NULLPTR))
                                 elif p.is_ptr and not p.obj and not p.is_ref:
                                     if p.is_input:
-                                        emit.Line("const %s %s = %s;" % (
-                                            p.str_nocvref, p.name, NULLPTR))
-                                        emit.Line("%s %s_length = reader.Lock%s(%s);" % (
-                                            p.length_type, p.name, p.RpcTypeNoCV(), p.name))
                                         emit.Line(
-                                            "reader.UnlockBuffer(%s_length);" % p.name)
+                                            "const %s %s = %s;" %
+                                            (p.str_nocvref, p.name, NULLPTR))
+                                        emit.Line(
+                                            "%s %s_length = reader.Lock%s(%s);"
+                                            % (p.length_type, p.name,
+                                               p.RpcTypeNoCV(), p.name))
+                                        emit.Line(
+                                            "reader.UnlockBuffer(%s_length);" %
+                                            p.name)
                                 elif p.is_ref and not p.is_input:
                                     emit.Line("%s %s{}; // storage" %
                                               (p.str_nocvref, p.name))
                                     if p.is_length or p.is_maxlength:
                                         raise TypenameError(
-                                            p.oclass, "'%s' is defined as a length variable but is write-only" % p.origname)
-                                elif not p.is_length or p.is_maxlength or not params[p.length_target].is_input:
-                                    emit.Line("%s %s = reader.%s();" % (
-                                        p.str_nocvref if p.proxy else p.str_noref, p.length_name if p.is_length else p.name, p.RpcTypeNoCV()))
+                                            p.oclass,
+                                            "'%s' is defined as a length variable but is write-only"
+                                            % p.origname)
+                                elif not p.is_length or p.is_maxlength or not params[
+                                        p.length_target].is_input:
+                                    emit.Line("%s %s = reader.%s();" %
+                                              (p.str_nocvref if p.proxy else
+                                               p.str_noref, p.length_name
+                                               if p.is_length else p.name,
+                                               p.RpcTypeNoCV()))
                                 if p.is_length:
                                     p.name = p.length_name
 
@@ -744,7 +826,8 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                                         if p.is_input:
                                             if p.maxlength_var:
                                                 emit.Line(
-                                                    "// allocate receive buffer if necessary")
+                                                    "// allocate receive buffer if necessary"
+                                                )
                                             oldname = p.name
                                             p.name = p.name + "_buffer"
                                         elif not p.is_input:
@@ -754,46 +837,69 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                                                   (p.str_nocvref, p.name))
                                         length_var = p.maxlength_var if p.maxlength_var else p.length_var
                                         if p.length_constant:
-                                            emit.Line("const %s %s = %s;" % (
-                                                p.length_type, p.length_var, p.length_expr))
+                                            emit.Line(
+                                                "const %s %s = %s;" %
+                                                (p.length_type, p.length_var,
+                                                 p.length_expr))
                                         if p.is_input:
                                             if p.maxlength_var:
                                                 # input/output and maxlength defined
-                                                emit.Line("%s = const_cast<%s>(%s);" % (
-                                                    p.name, p.str_nocvref, oldname))
-                                                emit.Line("if (%s > %s) {" % (
-                                                    p.maxlength_var, p.length_var))
-                                                emit.IndentInc()
-                                                if p.length_type not in ["char", "short", "int8_t", "uint8_t", "int16_t", "uint16_t"]:
-                                                    emit.Line(
-                                                        "ASSERT((%s < 0x10000) && \"Buffer too large\");" % length_var)
-                                                emit.Line("%s = static_cast<%s>(ALLOCA(%s));" % (
-                                                    p.name, p.str_nocvref, length_var))
                                                 emit.Line(
-                                                    "ASSERT(%s != nullptr);" % p.name)
+                                                    "%s = const_cast<%s>(%s);" %
+                                                    (p.name, p.str_nocvref,
+                                                     oldname))
+                                                emit.Line("if (%s > %s) {" %
+                                                          (p.maxlength_var,
+                                                           p.length_var))
+                                                emit.IndentInc()
+                                                if p.length_type not in [
+                                                        "char", "short",
+                                                        "int8_t", "uint8_t",
+                                                        "int16_t", "uint16_t"
+                                                ]:
+                                                    emit.Line(
+                                                        "ASSERT((%s < 0x10000) && \"Buffer too large\");"
+                                                        % length_var)
+                                                emit.Line(
+                                                    "%s = static_cast<%s>(ALLOCA(%s));"
+                                                    % (p.name, p.str_nocvref,
+                                                       length_var))
+                                                emit.Line(
+                                                    "ASSERT(%s != nullptr);" %
+                                                    p.name)
                                             else:
                                                 # is input/output but maxlength not defined
                                                 emit.Line(
-                                                    "%s = const_cast<%s>(%s); // reuse the input buffer" % (p.name, p.str_nocvref, oldname))
+                                                    "%s = const_cast<%s>(%s); // reuse the input buffer"
+                                                    % (p.name, p.str_nocvref,
+                                                       oldname))
                                         else:
                                             # is output-only
                                             if not p.length_constant:
-                                                emit.Line(
-                                                    "if (%s != 0) {" % p.length_var)
+                                                emit.Line("if (%s != 0) {" %
+                                                          p.length_var)
                                                 emit.IndentInc()
-                                            if p.length_type not in ["char", "short", "int8_t", "uint8_t", "int16_t", "uint16_t"]:
+                                            if p.length_type not in [
+                                                    "char", "short", "int8_t",
+                                                    "uint8_t", "int16_t",
+                                                    "uint16_t"
+                                            ]:
                                                 emit.Line(
-                                                    "ASSERT((%s < 0x10000) && \"Buffer length too big\");" % length_var)
-                                            emit.Line("%s = static_cast<%s>(ALLOCA(%s));" % (
-                                                p.name, p.str_nocvref, length_var))
+                                                    "ASSERT((%s < 0x10000) && \"Buffer length too big\");"
+                                                    % length_var)
                                             emit.Line(
-                                                "ASSERT(%s != nullptr);" % p.name)
+                                                "%s = static_cast<%s>(ALLOCA(%s));"
+                                                % (p.name, p.str_nocvref,
+                                                   length_var))
+                                            emit.Line("ASSERT(%s != nullptr);" %
+                                                      p.name)
                                             if not p.length_constant:
                                                 emit.IndentDec()
                                                 emit.Line("}")
                                         if p.is_input and p.maxlength_var:
-                                            emit.Line("::memcpy(%s, %s, %s);" % (
-                                                p.name, oldname, p.length_var))
+                                            emit.Line(
+                                                "::memcpy(%s, %s, %s);" %
+                                                (p.name, oldname, p.length_var))
                                             emit.IndentDec()
                                             emit.Line("}")
 
@@ -804,28 +910,33 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                                 emit.Line("%s %s = %s;" %
                                           (p.str_nocvref, proxy_name, NULLPTR))
                                 emit.Line(
-                                    "ProxyStub::UnknownProxy* %s_inst = %s;" % (proxy_name, NULLPTR))
-                                emit.Line("if (%s != %s) {" % (
-                                    p.name, NULLPTR))
+                                    "ProxyStub::UnknownProxy* %s_inst = %s;" %
+                                    (proxy_name, NULLPTR))
+                                emit.Line("if (%s != %s) {" % (p.name, NULLPTR))
                                 emit.IndentInc()
                                 # create proxy
-                                emit.Line("%s_inst = RPC::Administrator::Instance().ProxyInstance(channel, %s, %s::ID, false, %s::ID, true);"
-                                          % (proxy_name, p.name, p.str_typename, p.str_typename))
-                                emit.Line("if (%s_inst != %s) {" % (
-                                    proxy_name, NULLPTR))
+                                emit.Line(
+                                    "%s_inst = RPC::Administrator::Instance().ProxyInstance(channel, %s, %s::ID, false, %s::ID, true);"
+                                    % (proxy_name, p.name, p.str_typename,
+                                       p.str_typename))
+                                emit.Line("if (%s_inst != %s) {" %
+                                          (proxy_name, NULLPTR))
                                 emit.IndentInc()
-                                emit.Line("%s = %s_inst->QueryInterface<%s>();" %
-                                          (proxy_name, proxy_name, p.str_typename))
+                                emit.Line(
+                                    "%s = %s_inst->QueryInterface<%s>();" %
+                                    (proxy_name, proxy_name, p.str_typename))
                                 emit.IndentDec()
                                 emit.Line("}")
                                 emit.Line()
-                                emit.Line("ASSERT((%s != %s) && \"Failed to get instance of %s proxy\");"
-                                          % (proxy_name, NULLPTR, p.str_typename))
-                                emit.Line("if (%s == %s) {" % (
-                                    proxy_name, NULLPTR))
+                                emit.Line(
+                                    "ASSERT((%s != %s) && \"Failed to get instance of %s proxy\");"
+                                    % (proxy_name, NULLPTR, p.str_typename))
+                                emit.Line("if (%s == %s) {" %
+                                          (proxy_name, NULLPTR))
                                 emit.IndentInc()
                                 emit.Line(
-                                    "TRACE_L1(\"Failed to get instance of %s proxy\");" % p.str_typename)
+                                    "TRACE_L1(\"Failed to get instance of %s proxy\");"
+                                    % p.str_typename)
                                 emit.IndentDec()
                                 emit.Line("}")
                                 emit.IndentDec()
@@ -834,9 +945,12 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
 
                     if (retval.has_output or output_params) and proxy_count:
                         emit.Line("// write return value%s" %
-                                  ("s" if (int(retval.has_output) + output_params > 1) else ""))
+                                  ("s" if
+                                   (int(retval.has_output) + output_params > 1)
+                                   else ""))
                         emit.Line(
-                            "RPC::Data::Frame::Writer writer(message->Response().Writer());")
+                            "RPC::Data::Frame::Writer writer(message->Response().Writer());"
+                        )
                         emit.Line()
 
                     # emit code to validate the proxy(s)
@@ -849,33 +963,40 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                                 if_proxy_line += "((" + p.name + " == nullptr) || (" + p.name + "_proxy != %s" % NULLPTR + "))" + (
                                     " && " if (c != proxy_count - 1) else "")
                                 c += 1
-                        if_proxy_line += (")" if proxy_count >
-                                          1 else "") + " {"
+                        if_proxy_line += (")" if proxy_count > 1 else "") + " {"
                         emit.Line(if_proxy_line)
                         emit.IndentInc()
 
                     # emit function call
                     emit.Line("// call implementation")
-                    emit.Line("%s* implementation = input.Implementation<%s>();" %
-                              ((" ".join(m.qualifiers) + " " + iface_name).strip(), iface_name))
-                    emit.Line("ASSERT((implementation != %s) && \"Null %s implementation pointer\");" % (
-                        NULLPTR, iface_name))
+                    emit.Line(
+                        "%s* implementation = input.Implementation<%s>();" %
+                        ((" ".join(m.qualifiers) + " " + iface_name).strip(),
+                         iface_name))
+                    emit.Line(
+                        "ASSERT((implementation != %s) && \"Null %s implementation pointer\");"
+                        % (NULLPTR, iface_name))
                     call = ""
                     if retval.has_output:
                         call += "%s %s = " % (retval.str_noref, retval.name)
                     call += "implementation->%s(" % m.name
                     for c, p in enumerate(params):
-                        call += "%s%s%s%s" % ("&" if p.length_type == "void" else "", p.name,
-                                              ("_proxy" if p.proxy else ""), (", " if c < len(params) - 1 else ""))
+                        call += "%s%s%s%s" % (
+                            "&" if p.length_type == "void" else "", p.name,
+                            ("_proxy" if p.proxy else ""),
+                            (", " if c < len(params) - 1 else ""))
                     call += ");"
                     emit.Line(call)
 
                     if (retval.has_output or output_params) and not proxy_count:
                         emit.Line()
                         emit.Line("// write return value%s" %
-                                  ("s" if (int(retval.has_output) + output_params > 1) else ""))
+                                  ("s" if
+                                   (int(retval.has_output) + output_params > 1)
+                                   else ""))
                         emit.Line(
-                            "RPC::Data::Frame::Writer writer(message->Response().Writer());")
+                            "RPC::Data::Frame::Writer writer(message->Response().Writer());"
+                        )
 
                     # forward the output value
                     if retval.has_output:
@@ -885,24 +1006,33 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                                           retval.str_typename)
                                 if retval.obj.vars:
                                     for attr in retval.obj.vars:
-                                        emit.Line("writer.%s(output.%s);" % (
-                                            EmitParam(attr).RpcTypeNoCV(), attr.name))
+                                        emit.Line(
+                                            "writer.%s(output.%s);" %
+                                            (EmitParam(attr).RpcTypeNoCV(),
+                                             attr.name))
                                 else:
                                     raise TypenameError(
-                                        m, "method '%s': unable to decompose parameter type '%s': non-POD type" % (m.name, retval.str_typename))
+                                        m,
+                                        "method '%s': unable to decompose parameter type '%s': non-POD type"
+                                        % (m.name, retval.str_typename))
                             elif not retval.RpcType():
-                                raise TypenameError(m, "method '%s': unable to decompose parameter '%s': unknown type" % (
-                                    m.name, retval.str_typename))
+                                raise TypenameError(
+                                    m,
+                                    "method '%s': unable to decompose parameter '%s': unknown type"
+                                    % (m.name, retval.str_typename))
                         else:
                             emit.Line("writer.%s(%s);" %
                                       (retval.RpcType(), retval.name))
                             if retval.is_interface:
                                 if retval.typename == "void":
-                                    emit.Line("RPC::Administrator::Instance().RegisterInterface(channel, %s, %s);" % (
-                                        retval.name, retval.interface_ref.length_name))
+                                    emit.Line(
+                                        "RPC::Administrator::Instance().RegisterInterface(channel, %s, %s);"
+                                        % (retval.name,
+                                           retval.interface_ref.length_name))
                                 else:
                                     emit.Line(
-                                        "RPC::Administrator::Instance().RegisterInterface(channel, %s);" % retval.name)
+                                        "RPC::Administrator::Instance().RegisterInterface(channel, %s);"
+                                        % retval.name)
 
                     if output_params:
                         for p in params:
@@ -911,17 +1041,21 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                                     # temporarily remove the pointer
                                     temp = p.oclass
                                     temp.type.remove("*")
-                                    emit.Line("writer.%s(%s);" %
-                                              (EmitType(temp).RpcType(), p.name))
+                                    emit.Line(
+                                        "writer.%s(%s);" %
+                                        (EmitType(temp).RpcType(), p.name))
                                 else:
                                     if p.length_var and p.length_ref and p.length_ref.is_output:
-                                        emit.Line("writer.%s(%s);" % (
-                                            p.length_ref.RpcType(), p.length_var))
-                                    emit.Line("if ((%s != %s) && (%s != 0)) {" % (
-                                        p.name, NULLPTR, p.length_var))
+                                        emit.Line("writer.%s(%s);" %
+                                                  (p.length_ref.RpcType(),
+                                                   p.length_var))
+                                    emit.Line("if ((%s != %s) && (%s != 0)) {" %
+                                              (p.name, NULLPTR, p.length_var))
                                     emit.IndentInc()
-                                    emit.Line("writer.%s(%s, %s);" % (
-                                        p.RpcType(), p.length_var if p.length_var else p.maxlength_var, p.name))
+                                    emit.Line("writer.%s(%s, %s);" %
+                                              (p.RpcType(),
+                                               p.length_var if p.length_var else
+                                               p.maxlength_var, p.name))
                                     emit.IndentDec()
                                     emit.Line("}")
                             elif p.is_nonconstref:
@@ -930,18 +1064,21 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                                               (p.RpcType(), p.name))
                                 if p.is_interface:
                                     emit.Line(
-                                        "RPC::Administrator::Instance().RegisterInterface(channel, %s);" % p.name)
+                                        "RPC::Administrator::Instance().RegisterInterface(channel, %s);"
+                                        % p.name)
 
                     if proxy_count:
                         emit.IndentDec()
                         emit.String(emit.indent + "}")
-                        if any(x in ["uint32_t", "int", "long"] for x in str(retval.typename).split()):
+                        if any(x in ["uint32_t", "int", "long"]
+                               for x in str(retval.typename).split()):
                             emit.String(" else {")
                             emit.Line()
                             emit.IndentInc()
                             emit.Line("// return error code")
                             emit.Line(
-                                "writer.Number<const %s>(Core::ERROR_RPC_CALL_FAILED);" % retval.typename)
+                                "writer.Number<const %s>(Core::ERROR_RPC_CALL_FAILED);"
+                                % retval.typename)
                             emit.IndentDec()
                             emit.Line("}")
                         else:
@@ -951,11 +1088,12 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                         emit.Line()
                         for p in params:
                             if p.proxy:
-                                emit.Line("if (%s_proxy_inst != %s) {" % (
-                                    p.name, NULLPTR))
+                                emit.Line("if (%s_proxy_inst != %s) {" %
+                                          (p.name, NULLPTR))
                                 emit.IndentInc()
                                 emit.Line(
-                                    "RPC::Administrator::Instance().Release(%s_proxy_inst, message->Response());" % p.name)
+                                    "RPC::Administrator::Instance().Release(%s_proxy_inst, message->Response());"
+                                    % p.name)
                                 emit.IndentDec()
                                 emit.Line("}")
 
@@ -966,13 +1104,15 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                             "RPC::Data::Frame::Reader reader(input.Reader());")
                     if retval.has_output:
                         emit.Line(
-                            "RPC::Data::Frame::Writer writer(message->Response().Writer());")
+                            "RPC::Data::Frame::Writer writer(message->Response().Writer());"
+                        )
                     emit.Line("// TODO")
 
                 if EMIT_TRACES:
                     emit.Line()
                     emit.Line(
-                        'fprintf(stderr, "*** [%s stub] EXIT: %s()\\n");' % (iface.obj.full_name, m.name))
+                        'fprintf(stderr, "*** [%s stub] EXIT: %s()\\n");' %
+                        (iface.obj.full_name, m.name))
 
                 emit.IndentDec()
                 emit.Line("},\n")
@@ -985,23 +1125,26 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
         # EMIT PROXY CODE
         #
         emit.Line(
-            "// -----------------------------------------------------------------")
+            "// -----------------------------------------------------------------"
+        )
         emit.Line("// PROXY")
         emit.Line(
-            "// -----------------------------------------------------------------\n")
+            "// -----------------------------------------------------------------\n"
+        )
 
         for iface in interfaces:
             if (iface_namespace + "::") not in iface.obj.full_name:
                 continue
-            iface_name = iface.obj.full_name.split(
-                INTERFACE_NAMESPACE + "::", 1)[1]
+            iface_name = iface.obj.full_name.split(INTERFACE_NAMESPACE + "::",
+                                                   1)[1]
             if not iface_name in announce_list:
                 continue
 
             class_name = announce_list[iface_name][0]
 
             emit_methods = [
-                m for m in iface.obj.methods if "pure-virtual" in m.specifiers]
+                m for m in iface.obj.methods if "pure-virtual" in m.specifiers
+            ]
             if not emit_methods:
                 continue
 
@@ -1020,14 +1163,17 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
             emit.Line()
 
             # emit proxy class definition
-            emit.Line("class %s%s : public ProxyStub::UnknownProxyType<%s> {" % (
-                class_name, " final" if not USE_OLD_CPP else " /* final */", iface_name))
+            emit.Line(
+                "class %s%s : public ProxyStub::UnknownProxyType<%s> {" %
+                (class_name, " final" if not USE_OLD_CPP else " /* final */",
+                 iface_name))
             emit.Line("public:")
             emit.IndentInc()
 
             # emit constructor
             emit.Line(
-                "%s(const Core::ProxyType<Core::IPCChannel>& channel, void* implementation, const bool otherSideInformed)" % class_name)
+                "%s(const Core::ProxyType<Core::IPCChannel>& channel, void* implementation, const bool otherSideInformed)"
+                % class_name)
             emit.Line(
                 "    : BaseClass(channel, implementation, otherSideInformed)")
             emit.Line("{")
@@ -1053,11 +1199,15 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
 
                 for c, p in enumerate(params):
                     p.name += str(c)
-                    if (not p.is_nonconstref and not p.is_nonconstptr) or (p.is_input and not p.is_length) or (p.is_ptr and p.obj) or (p.is_length and not params[p.length_target].is_input):
+                    if (not p.is_nonconstref and not p.is_nonconstptr) or (
+                            p.is_input
+                            and not p.is_length) or (p.is_ptr and p.obj) or (
+                                p.is_length
+                                and not params[p.length_target].is_input):
                         input_params += 1
 
-                method_line = PrototypeStr(
-                    m, orig_params) + (" override" if not USE_OLD_CPP else " /* override */")
+                method_line = PrototypeStr(m, orig_params) + (
+                    " override" if not USE_OLD_CPP else " /* override */")
 
                 if m.omit:
                     emit.Line("// %s" % method_line)
@@ -1072,11 +1222,12 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                 emit.IndentInc()
                 if EMIT_TRACES:
                     emit.Line(
-                        'fprintf(stderr, "*** [%s proxy] ENTER: %s()\\n");' % (iface.obj.full_name, m.name))
+                        'fprintf(stderr, "*** [%s proxy] ENTER: %s()\\n");' %
+                        (iface.obj.full_name, m.name))
                     emit.Line()
 
-                emit.Line(
-                    "IPCMessage newMessage(BaseClass::Message(%i));" % count)
+                emit.Line("IPCMessage newMessage(BaseClass::Message(%i));" %
+                          count)
                 emit.Line()
                 count += 1
                 proxy_params = 0
@@ -1086,7 +1237,8 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                     if input_params:
                         emit.Line("// write parameters")
                         emit.Line(
-                            "RPC::Data::Frame::Writer writer(newMessage->Parameters().Writer());")
+                            "RPC::Data::Frame::Writer writer(newMessage->Parameters().Writer());"
+                        )
 
                         for c, p in enumerate(params):
                             if not p.is_ptr and not p.CheckRpcType():
@@ -1095,24 +1247,36 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                                         emit.Line("// (decompose %s)" %
                                                   p.str_typename)
                                         for attr in p.obj.vars:
-                                            emit.Line("writer.%s(param%i.%s);" % (
-                                                EmitParam(attr).RpcTypeNoCV(), c, attr.name))
+                                            emit.Line(
+                                                "writer.%s(param%i.%s);" %
+                                                (EmitParam(attr).RpcTypeNoCV(),
+                                                 c, attr.name))
                                     else:
                                         raise TypenameError(
-                                            m, "method '%s': unable to decompose parameter '%s': non-POD type" % (m.name, p.str_typename))
+                                            m,
+                                            "method '%s': unable to decompose parameter '%s': non-POD type"
+                                            % (m.name, p.str_typename))
                                 elif not p.RpcType():
-                                    raise TypenameError(m, "method '%s': unable to decompose parameter '%s': unknown type" % (
-                                        m.name, p.str_typename))
+                                    raise TypenameError(
+                                        m,
+                                        "method '%s': unable to decompose parameter '%s': unknown type"
+                                        % (m.name, p.str_typename))
                             else:
                                 if p.is_ptr and p.obj:
                                     proxy_params += 1
                                 if not p.obj and p.is_ptr:
                                     if p.is_input:
-                                        emit.Line("writer.%s(%s, param%i);" % (
-                                            p.RpcType(), p.length_expr, c))
+                                        emit.Line(
+                                            "writer.%s(%s, param%i);" %
+                                            (p.RpcType(), p.length_expr, c))
                                 elif not p.is_input and p.is_nonconstref and p.is_nonconstptr:
                                     pass
-                                elif (not p.is_length or not params[p.length_target].is_input or p.is_maxlength) and (p.is_input or (not p.is_nonconstref and not p.is_nonconstptr) or p.obj):
+                                elif (not p.is_length
+                                      or not params[p.length_target].is_input
+                                      or p.is_maxlength) and (
+                                          p.is_input or
+                                          (not p.is_nonconstref
+                                           and not p.is_nonconstptr) or p.obj):
                                     emit.Line("writer.%s(param%i);" %
                                               (p.RpcType(), c))
                         emit.Line()
@@ -1121,7 +1285,9 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                         if not p.is_ptr and not p.CheckRpcType():
                             pass
                         else:
-                            if (p.is_nonconstref and p.obj) or (not p.obj and p.is_outputptr) or (p.is_nonconstref and not p.is_length):
+                            if (p.is_nonconstref and p.obj) or (
+                                    not p.obj and p.is_outputptr) or (
+                                        p.is_nonconstref and not p.is_length):
                                 output_params += 1
 
                     retval_has_proxy = retval.has_output and retval.is_interface
@@ -1129,14 +1295,19 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                     emit.Line("// invoke the method handler")
                     if retval.has_output:
                         default = "{}"
-                        if isinstance(retval.typename, (CppParser.Typedef, CppParser.Enum)):
+                        if isinstance(retval.typename,
+                                      (CppParser.Typedef, CppParser.Enum)):
                             default = " = static_cast<%s>(~0)" % retval.str_nocvref
-                        emit.Line("%s %s%s%s;" % (
-                            retval.str_nocvref, retval.name, "_proxy" if retval_has_proxy else "", default))
+                        emit.Line(
+                            "%s %s%s%s;" %
+                            (retval.str_nocvref, retval.name,
+                             "_proxy" if retval_has_proxy else "", default))
                         # assume it's a status code
-                        if any(x in ["uint32_t"] for x in str(retval.typename).split()):
+                        if any(x in ["uint32_t"]
+                               for x in str(retval.typename).split()):
                             emit.Line(
-                                "if ((%s = Invoke(newMessage)) == Core::ERROR_NONE) {" % retval.name)
+                                "if ((%s = Invoke(newMessage)) == Core::ERROR_NONE) {"
+                                % retval.name)
                         else:
                             emit.Line(
                                 "if (Invoke(newMessage) == Core::ERROR_NONE) {")
@@ -1148,20 +1319,27 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                     else:
                         emit.Line("Invoke(newMessage);")
 
-                    if retval.has_output or (output_params > 0) or (proxy_params > 0):
+                    if retval.has_output or (output_params > 0) or (proxy_params
+                                                                    > 0):
                         emit.Line("// read return value%s" %
-                                  ("s" if (int(retval.has_output) + output_params > 1) else ""))
+                                  ("s" if
+                                   (int(retval.has_output) + output_params > 1)
+                                   else ""))
                         emit.Line(
-                            "RPC::Data::Frame::Reader reader(newMessage->Response().Reader());")
+                            "RPC::Data::Frame::Reader reader(newMessage->Response().Reader());"
+                        )
 
                     if retval.has_output:
                         if retval.is_interface:
                             if retval.obj:
-                                emit.Line("%s_proxy = reinterpret_cast<%s>(Interface(reader.Number<void*>(), %s::ID));" % (
-                                    retval.name, retval.str_nocvref, retval.str_typename))
+                                emit.Line(
+                                    "%s_proxy = reinterpret_cast<%s>(Interface(reader.Number<void*>(), %s::ID));"
+                                    % (retval.name, retval.str_nocvref,
+                                       retval.str_typename))
                             else:
-                                emit.Line("%s_proxy = Interface(reader.Number<void*>(),%s);" %
-                                          (retval.name, retval.interface_expr))
+                                emit.Line(
+                                    "%s_proxy = Interface(reader.Number<void*>(),%s);"
+                                    % (retval.name, retval.interface_expr))
                         else:
                             if not retval.is_ptr and not retval.CheckRpcType():
                                 if retval.obj:
@@ -1169,28 +1347,38 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                                               retval.str_typename)
                                     if retval.obj.vars:
                                         for attr in retval.obj.vars:
-                                            emit.Line("%s.%s = reader.%s();" % (
-                                                retval.name, attr.name, EmitParam(attr, cv=["const"]).RpcTypeNoCV()))
+                                            emit.Line(
+                                                "%s.%s = reader.%s();" %
+                                                (retval.name, attr.name,
+                                                 EmitParam(attr, cv=[
+                                                     "const"
+                                                 ]).RpcTypeNoCV()))
                                     else:
                                         raise TypenameError(
-                                            m, "method '%s': unable to decompose return value '%s': non-POD type" % (m.name, retval.str_typename))
+                                            m,
+                                            "method '%s': unable to decompose return value '%s': non-POD type"
+                                            % (m.name, retval.str_typename))
                                 elif not retval.RpcType():
-                                    raise TypenameError(m, "method '%s': unable to decompose '%s': unknown type" % (
-                                        m.name, retval.str_typename))
+                                    raise TypenameError(
+                                        m,
+                                        "method '%s': unable to decompose '%s': unknown type"
+                                        % (m.name, retval.str_typename))
                             else:
                                 emit.Line("%s = reader.%s();" %
                                           (retval.name, retval.RpcTypeNoCV()))
 
                     for p in params:
                         if p.is_nonconstref and p.is_interface:
-                            emit.Line("%s = reinterpret_cast<%s>(Interface(reader.Number<void*>(), %s::ID));" % (
-                                p.name, p.str_nocvref, p.str_typename))
+                            emit.Line(
+                                "%s = reinterpret_cast<%s>(Interface(reader.Number<void*>(), %s::ID));"
+                                % (p.name, p.str_nocvref, p.str_typename))
                         elif not p.obj and p.is_outputptr:
                             if p.length_var and p.length_ref and p.length_ref.is_output:
-                                emit.Line("%s = reader.%s();" % (
-                                    p.length_ref.name, p.length_ref.RpcType()))
-                            emit.Line("if ((%s != %s) && (%s != 0)) {" % (
-                                p.name, NULLPTR, p.length_expr))
+                                emit.Line(
+                                    "%s = reader.%s();" %
+                                    (p.length_ref.name, p.length_ref.RpcType()))
+                            emit.Line("if ((%s != %s) && (%s != 0)) {" %
+                                      (p.name, NULLPTR, p.length_expr))
                             emit.IndentInc()
                             emit.Line("reader.%s(%s, %s);" %
                                       (p.RpcType(), p.length_expr, p.name))
@@ -1213,23 +1401,27 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
                     if EMIT_TRACES:
                         emit.Line()
                         emit.Line(
-                            'fprintf(stderr, "*** [%s proxy] EXIT: %s()\\n");' % (iface.obj.full_name, m.name))
+                            'fprintf(stderr, "*** [%s proxy] EXIT: %s()\\n");' %
+                            (iface.obj.full_name, m.name))
 
                     if retval.has_output:
                         emit.Line()
-                        emit.Line("return %s%s;" % (
-                            retval.name, "_proxy" if retval_has_proxy else ""))
+                        emit.Line(
+                            "return %s%s;" %
+                            (retval.name, "_proxy" if retval_has_proxy else ""))
 
                 else:
                     if m.vars:
                         emit.Line(
-                            "RPC::Data::Frame::Writer writer(newMessage->Parameters().Writer());")
+                            "RPC::Data::Frame::Writer writer(newMessage->Parameters().Writer());"
+                        )
                         emit.Line("// TODO")
                         emit.Line()
 
                     if retval.has_output:
                         emit.Line(
-                            "RPC::Data::Frame::Reader reader(newMessage->Response().Reader());")
+                            "RPC::Data::Frame::Reader reader(newMessage->Response().Reader());"
+                        )
                         emit.Line("// TODO")
                         emit.Line()
 
@@ -1256,10 +1448,12 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
         # EMIT REGISTRATION CODE
         #
         emit.Line(
-            "// -----------------------------------------------------------------")
+            "// -----------------------------------------------------------------"
+        )
         emit.Line("// REGISTRATION")
         emit.Line(
-            "// -----------------------------------------------------------------")
+            "// -----------------------------------------------------------------"
+        )
         emit.Line()
         emit.Line("namespace {")
         emit.IndentInc()
@@ -1281,8 +1475,8 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
         emit.IndentInc()
 
         for key, val in announce_list.items():
-            emit.Line("RPC::Administrator::Instance().Announce<%s, %s, %s>();" % (
-                key, val[0], val[2]))
+            emit.Line("RPC::Administrator::Instance().Announce<%s, %s, %s>();" %
+                      (key, val[0], val[2]))
 
         emit.IndentDec()
         emit.Line("}")
@@ -1300,35 +1494,86 @@ def GenerateStubs(output_file, source_file, defaults="", scan_only=False):
 
     return interfaces
 
+
 # -------------------------------------------------------------------------
 # entry point
 
-
 if __name__ == "__main__":
     argparser = argparse.ArgumentParser(
-        description='Generate proxy stub code out of interface header files.', formatter_class=argparse.RawTextHelpFormatter)
+        description='Generate proxy stub code out of interface header files.',
+        formatter_class=argparse.RawTextHelpFormatter)
     argparser.add_argument(
-        'path', nargs="*", help="Interface file(s) or a directory(ies) with interface files")
-    argparser.add_argument("--help-tags", dest="help_tags", action="store_true",
-                           default=False, help="show help on supported source code tags and exit")
-    argparser.add_argument("--version", dest="show_version",
-                           action="store_true", default=False, help="display version")
-    argparser.add_argument("-i", dest="extra_include", metavar="FILE", action="store", default=DEFAULT_DEFINITIONS_FILE,
-                           help="include a C++ header file (default: include '%s')" % DEFAULT_DEFINITIONS_FILE)
-    argparser.add_argument("--namespace", dest="if_namespace", metavar="NS", type=str, action="store",
-                           default=INTERFACE_NAMESPACE, help="set namespace to look for interfaces in (default: %s)" % INTERFACE_NAMESPACE)
-    argparser.add_argument("--indent", dest="indent_size", metavar="SIZE", type=int, action="store",
-                           default=INDENT_SIZE, help="set code indentation in spaces (default: %i)" % INDENT_SIZE)
-    argparser.add_argument("--traces", dest="traces", action="store_true", default=False,
-                           help="emit traces in generated proxy/stub code (default: no extra traces)")
-    argparser.add_argument("--old-cpp", dest="old_cpp", action="store_true", default=False,
-                           help="do not emit some C++11 keywords (default: emit modern C++ code)")
-    argparser.add_argument("--no-warnings", dest="no_warnings", action="store_true",
-                           default=False, help="suppress all warnings (default: show warnings)")
-    argparser.add_argument("--keep", dest="keep_incomplete", action="store_true", default=False,
-                           help="keep incomplete files (default: remove partially generated files)")
-    argparser.add_argument("--verbose", dest="verbose", action="store_true",
-                           default=False, help="enable verbose output (default: verbose output disabled)")
+        'path',
+        nargs="*",
+        help="Interface file(s) or a directory(ies) with interface files")
+    argparser.add_argument(
+        "--help-tags",
+        dest="help_tags",
+        action="store_true",
+        default=False,
+        help="show help on supported source code tags and exit")
+    argparser.add_argument("--version",
+                           dest="show_version",
+                           action="store_true",
+                           default=False,
+                           help="display version")
+    argparser.add_argument(
+        "-i",
+        dest="extra_include",
+        metavar="FILE",
+        action="store",
+        default=DEFAULT_DEFINITIONS_FILE,
+        help="include a C++ header file (default: include '%s')" %
+        DEFAULT_DEFINITIONS_FILE)
+    argparser.add_argument(
+        "--namespace",
+        dest="if_namespace",
+        metavar="NS",
+        type=str,
+        action="store",
+        default=INTERFACE_NAMESPACE,
+        help="set namespace to look for interfaces in (default: %s)" %
+        INTERFACE_NAMESPACE)
+    argparser.add_argument("--indent",
+                           dest="indent_size",
+                           metavar="SIZE",
+                           type=int,
+                           action="store",
+                           default=INDENT_SIZE,
+                           help="set code indentation in spaces (default: %i)" %
+                           INDENT_SIZE)
+    argparser.add_argument(
+        "--traces",
+        dest="traces",
+        action="store_true",
+        default=False,
+        help=
+        "emit traces in generated proxy/stub code (default: no extra traces)")
+    argparser.add_argument(
+        "--old-cpp",
+        dest="old_cpp",
+        action="store_true",
+        default=False,
+        help="do not emit some C++11 keywords (default: emit modern C++ code)")
+    argparser.add_argument(
+        "--no-warnings",
+        dest="no_warnings",
+        action="store_true",
+        default=False,
+        help="suppress all warnings (default: show warnings)")
+    argparser.add_argument(
+        "--keep",
+        dest="keep_incomplete",
+        action="store_true",
+        default=False,
+        help="keep incomplete files (default: remove partially generated files)"
+    )
+    argparser.add_argument(
+        "--verbose",
+        dest="verbose",
+        action="store_true",
+        default=False,
+        help="enable verbose output (default: verbose output disabled)")
     args = argparser.parse_args(sys.argv[1:])
     DEFAULT_DEFINITIONS_FILE = args.extra_include
     INDENT_SIZE = args.indent_size if (
@@ -1347,17 +1592,30 @@ if __name__ == "__main__":
     if args.help_tags:
         print("The following special tags are supported:")
         print("   @stubgen:skip     - skip parsing of the rest of the file")
-        print("   @stubgen:omit     - omit generating code for the next item (class or method)")
         print(
-            "   @stubgen:stub     - generate empty stub for the next item (class or method)")
+            "   @stubgen:omit     - omit generating code for the next item (class or method)"
+        )
+        print(
+            "   @stubgen:stub     - generate empty stub for the next item (class or method)"
+        )
         print("For non-const pointer and reference method/function parameters:")
         print("   @in               - denotes an input parameter")
         print("   @out              - denotes an output parameter")
-        print("   @inout            - denotes an input/output parameter (equivalent of @in @out)")
-        print("   @length:<expr>    - specifies a buffer length value (a constant, a parameter name or a math expression)")
-        print("   @maxlength:<expr> - specifies a maximum buffer length value (a constant, a parameter name or a math expression),")
-        print("                       if not specified @length is used as maximum length, use round parenthesis for expressions,")
-        print("                       e.g.: @length:bufferSize @length:(width*height*4)")
+        print(
+            "   @inout            - denotes an input/output parameter (equivalent of @in @out)"
+        )
+        print(
+            "   @length:<expr>    - specifies a buffer length value (a constant, a parameter name or a math expression)"
+        )
+        print(
+            "   @maxlength:<expr> - specifies a maximum buffer length value (a constant, a parameter name or a math expression),"
+        )
+        print(
+            "                       if not specified @length is used as maximum length, use round parenthesis for expressions,"
+        )
+        print(
+            "                       e.g.: @length:bufferSize @length:(width*height*4)"
+        )
         print("")
         print("The tags shall be placed inside comments.")
         sys.exit()
@@ -1372,8 +1630,11 @@ if __name__ == "__main__":
         interface_files = []
         for elem in args.path:
             if os.path.isdir(elem):
-                interface_files += [os.path.join(elem, f) for f in os.listdir(elem) if (os.path.isfile(
-                    os.path.join(elem, f)) and re.match("I.*\\.h", f) and f != IDS_DEFINITIONS_FILE)]
+                interface_files += [
+                    os.path.join(elem, f) for f in os.listdir(elem)
+                    if (os.path.isfile(os.path.join(elem, f)) and re.match(
+                        "I.*\\.h", f) and f != IDS_DEFINITIONS_FILE)
+                ]
             elif os.path.isfile(elem):
                 interface_files += [elem]
             else:
@@ -1384,11 +1645,16 @@ if __name__ == "__main__":
         if interface_files:
             for source_file in interface_files:
                 try:
-                    output_file = os.path.join(os.path.dirname(source_file), PROXYSTUB_CPP_NAME % CreateName(
-                        os.path.basename(source_file)).split(".", 1)[0])
+                    output_file = os.path.join(
+                        os.path.dirname(source_file),
+                        PROXYSTUB_CPP_NAME % CreateName(
+                            os.path.basename(source_file)).split(".", 1)[0])
 
-                    output = GenerateStubs(output_file, source_file, os.path.join(os.path.dirname(
-                        os.path.realpath(__file__)), DEFAULT_DEFINITIONS_FILE), scan_only)
+                    output = GenerateStubs(
+                        output_file, source_file,
+                        os.path.join(
+                            os.path.dirname(os.path.realpath(__file__)),
+                            DEFAULT_DEFINITIONS_FILE), scan_only)
                     faces += output
 
                     log.Print("created file '%s'" % output_file)
@@ -1402,8 +1668,9 @@ if __name__ == "__main__":
                     log.Print("skipped file '%s'" % err)
                     skipped.append(source_file)
                 except NoInterfaceError as err:
-                    log.Info("no interface classes found in %s" %
-                             (INTERFACE_NAMESPACE), source_file)
+                    log.Info(
+                        "no interface classes found in %s" %
+                        (INTERFACE_NAMESPACE), source_file)
                 except TypenameError as err:
                     log.Error(err)
                     if not keep_incomplete and os.path.isfile(output_file):
@@ -1420,23 +1687,37 @@ if __name__ == "__main__":
                     if scan_only:
                         if i and sorted_faces[i - 1].id < f.id - 1:
                             print("...")
-                        print("%s (%s) - '%s'" % (hex(f.id) if isinstance(f.id,
-                                                                          int) else "?", str(f.id), f.obj.full_name))
+                        print("%s (%s) - '%s'" %
+                              (hex(f.id) if isinstance(f.id, int) else "?",
+                               str(f.id), f.obj.full_name))
                     if i and sorted_faces[i - 1].id == f.id:
-                        log.Warn("duplicate interface ID %s (%s) of %s" % (hex(f.id) if isinstance(
-                            f.id, int) else "?", str(f.id), f.obj.full_name), f.file)
+                        log.Warn(
+                            "duplicate interface ID %s (%s) of %s" %
+                            (hex(f.id) if isinstance(f.id, int) else "?",
+                             str(f.id), f.obj.full_name), f.file)
                 else:
-                    log.Info("can't evaluate interface ID \"%s\" of %s" %
-                             (str(f.id), f.obj.full_name), f.file)
+                    log.Info(
+                        "can't evaluate interface ID \"%s\" of %s" %
+                        (str(f.id), f.obj.full_name), f.file)
 
             if len(interface_files) > 1 and BE_VERBOSE:
                 print("")
 
-            log.Print(("all done; %i file%s processed" % (len(interface_files) - len(skipped), "s" if len(interface_files) - len(skipped) > 1 else "")) +
-                      ((" (%i file%s skipped)" % (len(skipped), "s" if len(skipped) > 1 else "")) if skipped else "") +
-                      ("; %i interface%s parsed:" % (len(faces), "s" if len(faces) > 1 else "")) +
-                      ((" %i error%s" % (len(log.errors), "s" if len(log.errors) > 1 else "")) if log.errors else " no errors") +
-                      ((" (%i warning%s)" % (len(log.warnings), "s" if len(log.warnings) > 1 else "")) if log.warnings else ""))
+            log.Print(
+                ("all done; %i file%s processed" %
+                 (len(interface_files) - len(skipped),
+                  "s" if len(interface_files) - len(skipped) > 1 else "")) +
+                ((" (%i file%s skipped)" %
+                  (len(skipped),
+                   "s" if len(skipped) > 1 else "")) if skipped else "") +
+                ("; %i interface%s parsed:" %
+                 (len(faces), "s" if len(faces) > 1 else "")) +
+                ((" %i error%s" %
+                  (len(log.errors), "s" if len(log.errors) > 1 else "")
+                  ) if log.errors else " no errors") +
+                ((" (%i warning%s)" %
+                  (len(log.warnings), "s" if len(log.warnings) > 1 else "")
+                  ) if log.warnings else ""))
         else:
             log.Print("Nothing to do")
 

--- a/Tools/ProxyStubGenerator/__init__.py
+++ b/Tools/ProxyStubGenerator/__init__.py
@@ -1,2 +1,2 @@
-import CppParser
-import Interface
+from . import CppParser
+from . import Interface

--- a/Tools/cmake/FindJsonGenerator.cmake.in
+++ b/Tools/cmake/FindJsonGenerator.cmake.in
@@ -1,5 +1,5 @@
 if(NOT PYTHON_EXECUTABLE)
-    find_package(PythonInterp 2.7 REQUIRED QUIET) 
+    find_package(PythonInterp 3.5 REQUIRED QUIET)
 endif()
 
 set(JSON_GENERATOR "@GENERATOR_INSTALL_PATH@/JsonGenerator/JsonGenerator.py")

--- a/Tools/cmake/FindProxyStubGenerator.cmake.in
+++ b/Tools/cmake/FindProxyStubGenerator.cmake.in
@@ -1,5 +1,5 @@
 if(NOT PYTHON_EXECUTABLE)
-    find_package(PythonInterp 2.7 REQUIRED QUIET) 
+    find_package(PythonInterp 3.5 REQUIRED QUIET)
 endif()
 
 set(PROXYSTUB_GENERATOR "@GENERATOR_INSTALL_PATH@/ProxyStubGenerator/StubGenerator.py")


### PR DESCRIPTION
The following changes were introduced to align with Python 3 syntax:
- Adjusted the print calls.
- Empty **filter** calls are no longer evaluated as a false boolean expression.
- Changed the inheritance order in **Value** class, in order to fix the inconsistent MRO issue.

Additionally the files were reformatted to fit the pep8 standard. 