### PR TITLE
[StateTrigger] Use InterlockedIncrement(m_InterestCount) to fix race

### DIFF
--- a/Source/core/StateTrigger.h
+++ b/Source/core/StateTrigger.h
@@ -92,7 +92,7 @@ namespace Core {
 
         // Now wait till our state is reached.
         while (((a_State & m_State) == 0) && (blTimeOut == false)) {
-            m_InterestCount++;
+            InterlockedIncrement(m_InterestCount);
 
             m_AdminLock.Unlock();
 
@@ -120,7 +120,7 @@ namespace Core {
 
         // Now wait till our state is reached.
         while (((a_State & m_State) != 0) && (blTimeOut == false)) {
-            m_InterestCount++;
+            InterlockedIncrement(m_InterestCount);
 
             m_AdminLock.Unlock();
 


### PR DESCRIPTION
There's a possible race condition around m_InterestCount between
different threads calling either WaitState() or WaitStateClear(), in
particular between threads incrementing it and other threads
decrementing it.

While the incrementing is done without an interlocked primitive with the
protecting mutex grabbed, the decrementing is done with an interlocked
primitive but without grabbing the mutex. This means that a thread doing
the non-interlocked incrementing might be descheduled in favor of a
thread doing the interlocked decrementing (which doesn't need to grab
the mutex), which will might result in an inconsistent value for
m_InterestCount in case the descheduled thread got interrupted after
loading the current value and before storing the incremented one.

Here's an example of the described problem, where two threads are
executing WaitState(). Note that 'm_InterestCount++' is decomposed into
3 instructions to clarify the problem. In the initial scenario,
m_InterestCount is 1, because Thread 2 already incremented and is
blocked on m_StateChange.Lock().

```
+----------------------+-------------------+----------------------------+--------------------------------------------------------------+
| Event                |  m_InterestCount  |  Thread 1 (T1)             | Thread 2 (T2)                                                |
+----------------------+-------------------+----------------------------+--------------------------------------------------------------+
| Initial              |  1                |  tmp = m_InterestCount = 1 | Blocked in m_StateChange.Lock(), not holding mutex           |
| Sched T1 out, T2 in  |  0                |  Waiting to run            | Executed InterlockedDecrement(m_InterestCount); and returned |
| Sched T2 out, T1 in  |  0                |  tmp = tmp + 1 = 2         | ---                                                          |
| Final                |  2                |  m_InterestCount = tmp = 2 | ---                                                          |
+----------------------+-------------------+----------------------------+--------------------------------------------------------------+
```

Although this seems and is very unlikely to happen, testing is showing
cases where the whole framework gets deadlocked because a thread is left
looping "forever" in the SetState() inner 'while' loop because
m_InterestCount is set to 1 and all the threads that are running or have
ran WaitState() on the same instance have already decremented it and are
already blocked on waiting to grab the mutex again. These cases are,
however, extremely hard to reproduce, so far only twice, but in both
cases the deadlock was exactly the same and as described.

Fix this by also using the interlocked functions on m_InterestCount when
incrementing it, even with the guard mutex grabbed. Using std:atomic
might also be a correct option, but it could add unnecessary memory
barriers when they are not being needed (in SetState()) which could hit
performance.

Signed-off-by: Ricardo Silva <ricardo.silva@gbtembedded.com>