### PR TITLE
[WPE-591][JSONRPC] Made jsonrpc errors more informative

### DIFF
--- a/Source/core/JSON.h
+++ b/Source/core/JSON.h
@@ -140,7 +140,7 @@ namespace Core {
                 }
 
                 if (error.IsSet() == true) {
-                    TRACE_L1(_T("Parsing failed: %s"), ErrorDisplayMessage(error.Value()).c_str());
+                    TRACE_L1("Parsing failed: %s", ErrorDisplayMessage(error.Value()).c_str());
                 }
 
                 return (error.IsSet() == false);
@@ -231,7 +231,7 @@ namespace Core {
                 }
 
                 if (error.IsSet() == true) {
-                    TRACE_L1(_T("Parsing failed with %s"), ErrorDisplayMessage(error.Value()).c_str());
+                    TRACE_L1("Parsing failed with %s", ErrorDisplayMessage(error.Value()).c_str());
                 }
 
                 return (error.IsSet() == false);
@@ -267,7 +267,7 @@ namespace Core {
                 if (error.IsSet() == true) {
                     Clear();
                     error.Value().Context(Stream, MaxLength, loaded);
-                    TRACE_L1(_T("Parsing failed: %s"), ErrorDisplayMessage(error.Value()).c_str());
+                    TRACE_L1("Parsing failed: %s", ErrorDisplayMessage(error.Value()).c_str());
                 }
 
                 return loaded;

--- a/Source/plugins/JSONRPC.h
+++ b/Source/plugins/JSONRPC.h
@@ -285,11 +285,11 @@ namespace PluginHost {
                 break;
             case STATE_INCORRECT_VERSION:
                 response->Error.SetError(Core::ERROR_INVALID_SIGNATURE);
-                response->Error.Text = _T("Destined invoke failed.");
+                response->Error.Text = _T("Requested version is not supported.");
                 break;
             case STATE_UNKNOWN_METHOD:
                 response->Error.SetError(Core::ERROR_UNKNOWN_KEY);
-                response->Error.Text = _T("Destined invoke failed.");
+                response->Error.Text = _T("Unknown method.");
                 break;
             case STATE_REGISTRATION:
                 info.FromString(inbound.Parameters.Value());


### PR DESCRIPTION
- HTTP response of failed JSONRPC requests are now more indicative of
  root cause.

- Now capturing of invalid JSON is done on an earlier stage. Previously
  even if the parser found errors, it was passed to further processing
  as empty JSONRPC message, only to be caught when the function 
  name (empty or garbage) was not matching the ones available to 
  Controller service (as Controller is selected when empty Callsign is 
  passed)

- There was a potential problem, that if there would be 2 plugins with
  names that are overlapping (eg. "Bluetooth" and "BluetoothControl")
  function ServiceMap::FromIdentifier could incorrectly report
  Core::ERROR_INVALID_SIGNATURE when requesting the service with 
  a longer name. This also caused different errors returned when service eg.
  "xxBluetooth" and "Bluetoothxx" were accessed (UNAVALIABLE and
  INVALID_SIGNATURE respectively)