### PR TITLE
[TRACING] Set string as quoted when using tracing file

### DIFF
--- a/Source/WPEFramework/PluginHost.cpp
+++ b/Source/WPEFramework/PluginHost.cpp
@@ -437,6 +437,7 @@ namespace PluginHost {
 
         if (serviceConfig.DefaultTraceCategories.IsQuoted() == true) {
 
+            serviceConfig.DefaultTraceCategories.SetQuoted(true);
             traceSettings = Core::Directory::Normalize(Core::File::PathName(options.configFile)) + serviceConfig.DefaultTraceCategories.Value();
 
             Core::File input (traceSettings, true);


### PR DESCRIPTION
When using a tracing file for the DefaultTraceCategories, the string
must be set as quoted using SetQuoted(true), otherwise the actual quotes
will show up when deserializing it and consequently cause failure to
open the tracing file.