### PR TITLE
[Process Containers] Made PC work with latest Thunder

### DIFF
--- a/Source/com/Communicator.h
+++ b/Source/com/Communicator.h
@@ -533,14 +533,14 @@ namespace RPC {
         };
 #ifdef PROCESSCONTAINERS_ENABLED
 
-        class EXTERNAL ContainerRemoteProcess : public LocalRemoteProcess {
+        class EXTERNAL ContainerRemoteProcess  : public RemoteConnection, public IMonitorableProcess {
         private:
-            class Config : public Core::JSON::Container {
+            class ContainerConfig : public Core::JSON::Container {
             public:
-                Config(const Config&) = delete;
-                Config& operator=(const Config&) = delete;
+                ContainerConfig(const ContainerConfig&) = delete;
+                ContainerConfig& operator=(const ContainerConfig&) = delete;
 
-                Config()
+                ContainerConfig()
                     : Core::JSON::Container()
 #ifdef __DEBUG__
                     , ContainerPath()
@@ -550,7 +550,7 @@ namespace RPC {
                     Add(_T("containerpath"), &ContainerPath);
 #endif
                 }
-                ~Config() = default;
+                ~ContainerConfig() = default;
 
 #ifdef __DEBUG__
                 Core::JSON::String ContainerPath;
@@ -563,17 +563,15 @@ namespace RPC {
             ContainerRemoteProcess(const ContainerRemoteProcess&) = delete;
             ContainerRemoteProcess& operator=(const ContainerRemoteProcess&) = delete;
 
-        private:
             ContainerRemoteProcess(const Config& baseConfig, const Object& instance)
-                : LocalRemoteProcess(config, instance)
+                : _callsign(instance.Callsign())
+                , _id(0)
+                , _process(RemoteConnection::Id(), baseConfig, instance)
             {
 
                 static constexpr TCHAR ContainerName[] = _T("Container");
 
                 ProcessContainers::IContainerAdministrator& admin = ProcessContainers::IContainerAdministrator::Instance();
-
-                Config config;
-                config.FromString(instance.Configuration());
 
                 std::vector<string> searchpaths(3);
                 searchpaths[0] = baseConfig.VolatilePath();
@@ -581,6 +579,8 @@ namespace RPC {
                 searchpaths[2] = baseConfig.DataPath();
 
 #ifdef __DEBUG__
+                ContainerConfig config;
+                config.FromString(instance.Configuration());
 
                 if (config.ContainerPath.IsSet() == true) {
                     searchpaths.emplace(searchpaths.cbegin(), config.ContainerPath.Value());
@@ -590,7 +590,8 @@ namespace RPC {
 
                 Core::IteratorType<std::vector<string>, const string> searchpathsit(searchpaths);
 
-                _container = admin.Container(ContainerName, searchpathsit, volatilecallsignpath, configuration);
+                string volatilecallsignpath(baseConfig.VolatilePath() + instance.Callsign() + _T('/'));
+                _container = admin.Container(ContainerName, searchpathsit, volatilecallsignpath, instance.Configuration());
 
                 admin.Release();
             }
@@ -602,12 +603,19 @@ namespace RPC {
                 }
             }
 
-            void Launch()
+            string Callsign() const override
             {
+                return (_callsign);
+            }
+
+            uint32_t Launch() override
+            {
+                uint32_t result = Core::ERROR_GENERAL;
+
                 if (_container != nullptr) {
 
                     // Note: replace below code with something more efficient when Iterators redesigned
-                    Core::Process::Options::Iterator it(LocalRemoteProcess::Options());
+                    Core::Process::Options::Iterator it(_process.Options());
 
                     std::vector<string> params;
                     while (it.Next() == true) {
@@ -615,11 +623,19 @@ namespace RPC {
                     }
 
                     Core::IteratorType<std::vector<string>, const string> temp(params);
-                    _container->Start(LocalRemoteProcess::Command(), temp);
-                }
+                    if (_container->Start(_process.Command(), temp) == true) {
+                        result = Core::ERROR_NONE;
+                    } 
+                } 
+
+                return result;
             }
 
-        public:
+        private:
+            BEGIN_INTERFACE_MAP(ContainerRemoteProcess)
+                INTERFACE_ENTRY(IRemoteConnection)
+                INTERFACE_ENTRY(IMonitorableProcess)
+            END_INTERFACE_MAP
             void Terminate() override;
 
             uint32_t RemoteId() const override
@@ -629,6 +645,9 @@ namespace RPC {
 
         private:
             ProcessContainers::IContainer* _container;
+            string _callsign;
+            uint32_t _id;
+            Process _process;
         };
 
 #endif

--- a/Source/processcontainers/implementations/LXCImplementation/LXCImplementation.cpp
+++ b/Source/processcontainers/implementations/LXCImplementation/LXCImplementation.cpp
@@ -128,9 +128,6 @@ namespace ProcessContainers {
         , _containerLogDir(containerLogDir)
         , _referenceCount(1)
         , _lxcContainer(lxcContainer)
-#ifdef __DEBUG__
-        , _attach(false)
-#endif
     {
         Config config;
         Core::OptionalType<Core::JSON::Error> error;
@@ -142,12 +139,7 @@ namespace ProcessContainers {
 #ifdef __DEBUG__
             _attach = config.Attach.Value();
 #endif
-        string pathName;
-        Core::SystemInfo::GetEnvironment("PATH", pathName);
-        string key("PATH");
-        key += "=";
-        key += pathName;
-        _lxcContainer->set_config_item(_lxcContainer, "lxc.environment", key.c_str());
+        InheritRequestedEnvironment();
 
         if( config.ConsoleLogging.Value() != _T("0") ) {
 
@@ -278,34 +270,34 @@ namespace ProcessContainers {
     {
         bool result = false;
 
-        std::vector<const char*> params(parameters.Count()+2);
+        std::vector<const char*> params;
+        params.reserve(parameters.Count()+2);
         parameters.Reset(0);
-        uint16_t pos = 0;
-        params[pos++] = command.c_str();
+
+        params.push_back(command.c_str());
 
         while( parameters.Next() == true ) {
-            params[pos++] = parameters.Current().c_str();
+            params.push_back(parameters.Current().c_str());
         }
-        params[pos++] = nullptr;
-        ASSERT(pos == parameters.Count()+2);
+        params.push_back(nullptr);
 
 #ifdef __DEBUG__
-            if( _attach == true ) {
-                result = _lxcContainer->start(_lxcContainer, 0, NULL);
-                if( result == true ) {
+        if( _attach == true ) {
+            result = _lxcContainer->start(_lxcContainer, 0, NULL);
+            if( result == true ) {
 
-                    lxc_attach_command_t lxccommand;
-                    lxccommand.program = (char *)command.c_str();
-                    lxccommand.argv = const_cast<char**>(params.data());
+                lxc_attach_command_t lxccommand;
+                lxccommand.program = (char *)command.c_str();
+                lxccommand.argv = const_cast<char**>(params.data());
 
-                    lxc_attach_options_t options = LXC_ATTACH_OPTIONS_DEFAULT;
-                    int ret = _lxcContainer->attach(_lxcContainer, lxc_attach_run_command, &lxccommand, &options, reinterpret_cast<pid_t*>(&_pid));
-                    if( ret != 0 ) {
-                        _lxcContainer->shutdown(_lxcContainer, 0);
-                    }
-                    result = ret == 0;
+                lxc_attach_options_t options = LXC_ATTACH_OPTIONS_DEFAULT;
+                int ret = _lxcContainer->attach(_lxcContainer, lxc_attach_run_command, &lxccommand, &options, reinterpret_cast<pid_t*>(&_pid));
+                if( ret != 0 ) {
+                    _lxcContainer->shutdown(_lxcContainer, 0);
                 }
-            } else
+                result = (ret == 0);
+            }
+        } else
 #endif
         {
             result = _lxcContainer->start(_lxcContainer, 0, const_cast<char**>(params.data()));
@@ -356,6 +348,38 @@ namespace ProcessContainers {
         return retval;
     }
 
+    void LXCContainer::InheritRequestedEnvironment() {
+        // According to https://linuxcontainers.org/lxc/manpages/man5/lxc.container.conf.5.html#lbBM we
+        // should be able to inherit env variables from host by using config syntax lxc.environment = ENV_NAME.
+        // For some reason this doesn't work with current build of lxc, so we have to provide this functionality
+        // from by ourselves 
+
+        uint32_t len = _lxcContainer->get_config_item(_lxcContainer, "lxc.environment", nullptr, 0 );
+        if (len > 0) {
+            char* buffer = new char[len];
+
+            uint32_t read = _lxcContainer->get_config_item(_lxcContainer, "lxc.environment", buffer, len);
+
+            if (read > 0) {
+                char* tmp;
+                char* token = strtok_r(buffer, "\n", &tmp);
+
+                while (token != nullptr) {
+                    if (strchr(token, '=') == nullptr) {
+                        string envVar;
+                        Core::SystemInfo::GetEnvironment(token, envVar);
+                        string key = string(token) + "=" + envVar;
+                        _lxcContainer->set_config_item(_lxcContainer, "lxc.environment", key.c_str());
+                    }
+
+                    token = strtok_r(nullptr, "\n", &tmp);
+                }
+            }
+
+            delete[] buffer;
+        }
+    }
+
     LXCContainerAdministrator::LXCContainerAdministrator() 
         : _lock() 
         ,_containers()
@@ -379,6 +403,7 @@ namespace ProcessContainers {
             LxcContainerType **clist = nullptr;
             int32_t numberofcontainersfound = list_defined_containers(searchpaths.Current().c_str(), nullptr, &clist);
             int32_t index = 0;
+
             while( ( container == nullptr) && ( index < numberofcontainersfound ) ) {
                 LxcContainerType *c = clist[index];
                 if( name == c->name ) {

--- a/Source/processcontainers/implementations/LXCImplementation/LXCImplementation.h
+++ b/Source/processcontainers/implementations/LXCImplementation/LXCImplementation.h
@@ -102,16 +102,19 @@ namespace ProcessContainers {
         void AddRef() const override;
         uint32_t Release() override;
 
-        private:
-            const string _name;
-            uint32_t _pid;
-            string _lxcPath;
-            string _containerLogDir;
-            mutable Core::CriticalSection _adminLock;
-            mutable uint32_t _referenceCount;
-            LxcContainerType* _lxcContainer;
+    protected:
+        void InheritRequestedEnvironment();
+
+    private:
+        const string _name;
+        uint32_t _pid;
+        string _lxcPath;
+        string _containerLogDir;
+        mutable Core::CriticalSection _adminLock;
+        mutable uint32_t _referenceCount;
+        LxcContainerType* _lxcContainer;
 #ifdef __DEBUG__
-            bool _attach;
+        bool _attach;
 #endif
     };
 


### PR DESCRIPTION
There were changes in the way how plugins are started, that made
containers do not compile anymore. This pull fixes that.

Also, now more environment variables are required to be present to
correctly start a WPEProcess (previously only PATH was set to the 
container, but not really needed). That uncovered a bug in LXC, 
where environmental variables are not inherited from host even if they 
are requested in a container config file. That was fixed by implementing
this functionality on Thunder side.

In future it might be fixed from LXC side. Then the fix in Thunder will
be unneccessary, but shouldn't affect the correct LXC solution in a
conflicting way.