### PR TITLE
IPCChannel: Fix iteration on CloseClients() first loop

### DIFF
--- a/Source/core/IPCChannel.h
+++ b/Source/core/IPCChannel.h
@@ -447,7 +447,7 @@ namespace Core {
             typename ClientMap::iterator index(_clients.begin());
 
             while (index != _clients.end()) {
-                Core::ProxyType<Client> item(_clients.begin()->second);
+                Core::ProxyType<Client> item(index->second);
 
                 if (item->Source().IsClosed() == false) {
                     if (item->Source().Close(0) != Core::ERROR_NONE) {


### PR DESCRIPTION
The first while loop in CloseClients(), which is used for
requesting/forcing the closing of clients that are not yet closed, is
not really iterating, but just revisiting the first entry for the whole
loop.

This happens because the incrementing 'index' is not being used to
select the current 'item', as at the beginning of each iteration the
current is always set to the first item (_clients.begin()).

Fix this by instead taking the current 'item' from the 'index' (which is
being incremented).

This is causing scenarios where the deactivation of plugins is failing
(or timing out), because the first loop in CloseClients() is not
requesting all the required closes (only on first client) and then the
second loop will wait forever for the clients to actually be closed. In
case of OOP plugins, this leaves the plugin running "forever".